### PR TITLE
prepare 1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@ LaunchDarkly Client-side SDK for Flutter
 ===========================
 
 [![Circle CI](https://circleci.com/gh/launchdarkly/flutter-client-sdk.svg?style=shield)](https://circleci.com/gh/launchdarkly/flutter-client-sdk)
-
-*This version of the SDK is a **beta** version and should not be considered ready for production use while this message is visible.*
+[![Pub](https://img.shields.io/pub/v/launchdarkly_flutter_client_sdk.svg)](https://pub.dev/packages/launchdarkly_flutter_client_sdk)
 
 LaunchDarkly overview
 -------------------------


### PR DESCRIPTION
## [1.0.0] - 2021-10-29
First supported release of LaunchDarkly's Flutter SDK. This release contains no SDK code changes from the prior beta release.

### Added:
- Support for LaunchDarkly's internal release tool.