### PR TITLE
Replace jcenter with mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.4.32'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.4.32'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

[Gradle is experiencing a major outage](https://status.gradle.com/) related to jcenter. As the repository is RO and can't receive new packages, it shouldn't be referenced as a repository for Android packages.

![image](https://user-images.githubusercontent.com/865897/149231185-87bb5c92-4c7f-4276-be80-36b3164df8fa.png)

**Describe the solution you've provided**

jcenter is replaced by MavenCentral which will have up-to-date dependency versions. LaunchDarkly's client SDK is published on MavenCentral.

**Describe alternatives you've considered**

jcenter could be left as a repository but there's no clear gain to this as users that fetch from jcenter will receive dated versions that do not include bug fixes, or more critically, security patches. 