### PR TITLE
Removing XDG home conditional in publish.sh

### DIFF
--- a/.ldrelease/publish.sh
+++ b/.ldrelease/publish.sh
@@ -3,11 +3,7 @@
 set -e
 
 # Copy secret to allow publishing
-if [ -z "${XDG_CONFIG_HOME:-}" ]; then
-	# Linux with XDG_CONFIG_HOME defined.
-	mkdir -p $XDG_CONFIG_HOME/dart
-	mv $LD_RELEASE_SECRETS_DIR/pub_creds $XDG_CONFIG_HOME/dart/pub-credentials.json
-elif [ "$(uname)" == "Darwin" ]; then
+if [ "$(uname)" == "Darwin" ]; then
 	# Mac
 	mkdir -p ~/Library/Application Support/dart/
 	mv $LD_RELEASE_SECRETS_DIR/pub_creds ~/Library/Application Support/dart/pub-credentials.json


### PR DESCRIPTION
**Additional context**
Removing conditional in which XDG_CONFIG_HOME was empty.
