### PR TITLE
prepare 2.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the LaunchDarkly Flutter client-side SDK will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org).
 
+## [2.0.1] - 2023-06-07
+### Fixed:
+- Flag listeners are now called correctly after identify results in flag value changes.
+
 ## [2.0.0] - 2023-04-26
 The latest version of this SDK supports LaunchDarkly's new custom contexts feature. Contexts are an evolution of a previously-existing concept, "users." Contexts let you create targeting rules for feature flags based on a variety of different information, including attributes pertaining to users, organizations, devices, and more. You can even combine contexts to create "multi-contexts." 
 


### PR DESCRIPTION
## [2.0.2] - 2023-06-16
### Fixed:
- Fixes threading issue in start routine in Android native code