### PR TITLE
build(deps): Allow uuid 3.x and 4.x

### DIFF
--- a/packages/common/pubspec.yaml
+++ b/packages/common/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   http: ^1.1.0
   # http uses http_parser, so the versions should be kept compatible.
   http_parser: ^4.0.0
-  uuid: ^3.0.7
+  uuid: ">= 3.0.7 <5.0.0"
   crypto: ^3.0.3
 
 dev_dependencies:

--- a/packages/common_client/pubspec.yaml
+++ b/packages/common_client/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   launchdarkly_dart_common: 0.0.1
   launchdarkly_event_source_client: 0.0.2
   crypto: ^3.0.3
-  uuid: ^3.0.7
+  uuid: ">= 3.0.7 <5.0.0"
 
 dev_dependencies:
   test: ^1.24.3


### PR DESCRIPTION
The API used by the SDK should be the same with 3.x and 4.x of UUID.