### PR TITLE
Use a PAT for release-please to allow secondary workflow.

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,9 +15,18 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Normally a workflow cannot trigger another workflow. For this workflow we need to create a
+      # tag that will trigger another workflow. Github determines that something is created by
+      # a workflow/bot based on the token. So to allow the tag creation to trigger a workflow
+      # we must use a personal access token.
+      - uses: ./actions/release-secrets
+        name: "Get PAT"
+        with:
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          ssm_parameter_pairs: "/production/common/releasing/flutter_gh_pat = GITHUB_PAT"
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
           command: manifest
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{ env.GITHUB_PAT }}
           default-branch: main


### PR DESCRIPTION
Explained in comments. Link to base reason: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow