### PR TITLE
feat: adds contract tests for verifying client instance independence

### DIFF
--- a/apps/flutter_client_contract_test_service/bin/contract_test_service.dart
+++ b/apps/flutter_client_contract_test_service/bin/contract_test_service.dart
@@ -13,16 +13,17 @@ import 'service_api.openapi.dart';
 
 class TestApiImpl extends SdkTestApi {
   static const capabilities = [
-    "client-side",
-    "mobile",
-    "strongly-typed",
-    "context-type",
-    "context-comparison",
-    "service-endpoints",
-    "tags",
+    'client-side',
+    'mobile',
+    'strongly-typed',
+    'context-type',
+    'context-comparison',
+    'service-endpoints',
+    'tags',
+    'client-independence',
   ];
 
-  static const clientUrlPrefix = "/client/";
+  static const clientUrlPrefix = '/client/';
   static const defaultWaitTimeMillis = 5000;
 
   final Map<int, LDClient> clientMap = {};
@@ -41,7 +42,7 @@ class TestApiImpl extends SdkTestApi {
     final startWaitTimeMillis =
         body.configuration?.startWaitTimeMs?.toInt() ?? defaultWaitTimeMillis;
     final config = LDConfig(
-      body.configuration?.credential ?? "",
+      body.configuration?.credential ?? '',
       AutoEnvAttributes.disabled,
       applicationInfo: body.configuration?.tags?.applicationId != null
           ? ApplicationInfo(
@@ -396,7 +397,7 @@ void main() async {
   final server = OpenApiShelfServer(
     SdkTestApiRouter(ApiEndpointProvider.static(TestApiImpl())),
   );
-  print("Server listening on port $port");
+  print('Server listening on port $port');
   final process = await server.startServer(port: port);
   await process.exitCode;
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

https://app.shortcut.com/launchdarkly/story/230612/ensure-multiple-instantiated-sdks-work-together-in-harmony