### PR TITLE
fix: anonymous context keys and auto env context keys are now in separate namespaces

### DIFF
--- a/packages/common_client/lib/src/context_modifiers/anonymous_context_modifier.dart
+++ b/packages/common_client/lib/src/context_modifiers/anonymous_context_modifier.dart
@@ -29,7 +29,10 @@ final class AnonymousContextModifier implements ContextModifier {
       for (var MapEntry(key: kind, value: attributes)
           in context.attributesByKind.entries) {
         if (attributes.anonymous && attributes.key == '') {
-          newBuilder.kind(kind, await getOrGenerateKey(_persistence, _anonContextKeyNamespace, kind));
+          newBuilder.kind(
+              kind,
+              await getOrGenerateKey(
+                  _persistence, _anonContextKeyNamespace, kind));
         }
       }
       return newBuilder.build();

--- a/packages/common_client/lib/src/context_modifiers/anonymous_context_modifier.dart
+++ b/packages/common_client/lib/src/context_modifiers/anonymous_context_modifier.dart
@@ -4,6 +4,8 @@ import '../persistence/persistence.dart';
 import 'context_modifier.dart';
 import 'utils.dart';
 
+const _anonContextKeyNamespace = 'LaunchDarkly_AnonContextKey';
+
 final class AnonymousContextModifier implements ContextModifier {
   final Persistence _persistence;
 
@@ -27,7 +29,7 @@ final class AnonymousContextModifier implements ContextModifier {
       for (var MapEntry(key: kind, value: attributes)
           in context.attributesByKind.entries) {
         if (attributes.anonymous && attributes.key == '') {
-          newBuilder.kind(kind, await getOrGenerateKey(_persistence, kind));
+          newBuilder.kind(kind, await getOrGenerateKey(_persistence, _anonContextKeyNamespace, kind));
         }
       }
       return newBuilder.build();

--- a/packages/common_client/lib/src/context_modifiers/env_context_modifier.dart
+++ b/packages/common_client/lib/src/context_modifiers/env_context_modifier.dart
@@ -100,7 +100,8 @@ final class AutoEnvContextModifier implements ContextModifier {
       ),
       _ContextRecipe(
         AutoEnvConsts.ldDeviceKind,
-        () => getOrGenerateKey(_persistence, _autoEnvContextKeyNamespace, AutoEnvConsts.ldDeviceKind),
+        () => getOrGenerateKey(_persistence, _autoEnvContextKeyNamespace,
+            AutoEnvConsts.ldDeviceKind),
         deviceNodes,
       ),
     ];

--- a/packages/common_client/lib/src/context_modifiers/env_context_modifier.dart
+++ b/packages/common_client/lib/src/context_modifiers/env_context_modifier.dart
@@ -4,6 +4,8 @@ import '../persistence/persistence.dart';
 import 'context_modifier.dart';
 import 'utils.dart';
 
+const _autoEnvContextKeyNamespace = 'LaunchDarkly_AutoEnvContextKey';
+
 final class AutoEnvConsts {
   static const String ldApplicationKind = 'ld_application';
   static const String ldDeviceKind = 'ld_device';
@@ -98,7 +100,7 @@ final class AutoEnvContextModifier implements ContextModifier {
       ),
       _ContextRecipe(
         AutoEnvConsts.ldDeviceKind,
-        () => getOrGenerateKey(_persistence, AutoEnvConsts.ldDeviceKind),
+        () => getOrGenerateKey(_persistence, _autoEnvContextKeyNamespace, AutoEnvConsts.ldDeviceKind),
         deviceNodes,
       ),
     ];

--- a/packages/common_client/lib/src/context_modifiers/utils.dart
+++ b/packages/common_client/lib/src/context_modifiers/utils.dart
@@ -1,17 +1,15 @@
 import 'package:uuid/uuid.dart';
 import '../persistence/persistence.dart';
 
-const _generatedKeyNamespace = 'LaunchDarkly_GeneratedContextKeys';
-
 /// Retrieves the key for the given [kind] from [persistence] if it exists.  If
 /// one does not exist, generates a key, saves it, and returns it.
-Future<String> getOrGenerateKey(Persistence persistence, String kind) async {
+Future<String> getOrGenerateKey(Persistence persistence, String namespace, String kind) async {
   final encodedKind = encodePersistenceKey(kind);
-  final stored = await persistence.read(_generatedKeyNamespace, encodedKind);
+  final stored = await persistence.read(namespace, encodedKind);
   if (stored != null) {
     return stored;
   }
   final newKey = Uuid().v4();
-  await persistence.set(_generatedKeyNamespace, encodedKind, newKey);
+  await persistence.set(namespace, encodedKind, newKey);
   return newKey;
 }

--- a/packages/common_client/lib/src/context_modifiers/utils.dart
+++ b/packages/common_client/lib/src/context_modifiers/utils.dart
@@ -1,7 +1,7 @@
 import 'package:uuid/uuid.dart';
 import '../persistence/persistence.dart';
 
-/// Retrieves the key for the given [kind] from [persistence] if it exists.  If
+/// Retrieves the key from [persistence] for the given [namespace] and [kind] if it exists.  If
 /// one does not exist, generates a key, saves it, and returns it.
 Future<String> getOrGenerateKey(Persistence persistence, String namespace, String kind) async {
   final encodedKind = encodePersistenceKey(kind);

--- a/packages/common_client/lib/src/context_modifiers/utils.dart
+++ b/packages/common_client/lib/src/context_modifiers/utils.dart
@@ -3,7 +3,8 @@ import '../persistence/persistence.dart';
 
 /// Retrieves the key from [persistence] for the given [namespace] and [kind] if it exists.  If
 /// one does not exist, generates a key, saves it, and returns it.
-Future<String> getOrGenerateKey(Persistence persistence, String namespace, String kind) async {
+Future<String> getOrGenerateKey(
+    Persistence persistence, String namespace, String kind) async {
   final encodedKind = encodePersistenceKey(kind);
   final stored = await persistence.read(namespace, encodedKind);
   if (stored != null) {

--- a/packages/common_client/test/context_decorators/anonymous_context_modifier_test.dart
+++ b/packages/common_client/test/context_decorators/anonymous_context_modifier_test.dart
@@ -70,7 +70,7 @@ void main() {
           .build();
 
       final mockPersistence = MockPersistence();
-      mockPersistence.storage['LaunchDarkly_GeneratedContextKeys'] = {
+      mockPersistence.storage['LaunchDarkly_AnonContextKey'] = {
         encodePersistenceKey('user'): 'the-user-key',
         encodePersistenceKey('company'): 'the-company-key',
       };
@@ -98,11 +98,11 @@ void main() {
 
       expect(
           decoratedContext.attributesByKind['user']!.key,
-          mockPersistence.storage['LaunchDarkly_GeneratedContextKeys']![
+          mockPersistence.storage['LaunchDarkly_AnonContextKey']![
               encodePersistenceKey('user')]);
       expect(
           decoratedContext.attributesByKind['company']!.key,
-          mockPersistence.storage['LaunchDarkly_GeneratedContextKeys']![
+          mockPersistence.storage['LaunchDarkly_AnonContextKey']![
               encodePersistenceKey('company')]);
     });
   });


### PR DESCRIPTION
**Related issues**

https://app.shortcut.com/launchdarkly/story/231552/ensure-device-keys-are-a-different-namespace-than-anonymous-keys
