### PR TITLE
fix: making context builder easier to use

### DIFF
--- a/apps/flutter_client_contract_test_service/bin/contract_test_service.dart
+++ b/apps/flutter_client_contract_test_service/bin/contract_test_service.dart
@@ -356,7 +356,8 @@ class TestApiImpl extends SdkTestApi {
           builder.kind(attributes['kind'] ?? 'user', attributes['key']);
       for (final a in attributes.entries) {
         if (a.key == 'kind' || a.key == 'key') continue;
-        attrsBuilder.set(a.key, common.LDValueSerialization.fromJson(a.value));
+        attrsBuilder.setValue(
+            a.key, common.LDValueSerialization.fromJson(a.value));
       }
       final Map<String, dynamic> meta = attributes['_meta'] ?? {};
       final List<String> privateAttrs =

--- a/packages/common/test/ld_context_test.dart
+++ b/packages/common/test/ld_context_test.dart
@@ -77,7 +77,7 @@ void main() {
   test('can set custom attributes', () {
     final context = LDContextBuilder()
         .kind('user', 'user-key')
-        .set('customA', LDValue.ofNum(42))
+        .setNum('customA', 42)
         .build();
 
     expect(context.get('user', AttributeReference('customA')).intValue(), 42);
@@ -86,7 +86,8 @@ void main() {
   test('can get a nested attribute', () {
     final context = LDContextBuilder()
         .kind('org', 'org-key')
-        .set('myJson', LDValue.buildObject().addBool('myBool', true).build())
+        .setValue(
+            'myJson', LDValue.buildObject().addBool('myBool', true).build())
         .build();
 
     expect(
@@ -115,7 +116,7 @@ void main() {
       () {
     final context = LDContextBuilder()
         .kind('org', 'org-key')
-        .set('myJson',
+        .setValue('myJson',
             LDValue.buildObject().addString('myString', 'true').build())
         .build();
 
@@ -127,7 +128,8 @@ void main() {
       () {
     final context = LDContextBuilder()
         .kind('org', 'org-key')
-        .set('myJson', LDValue.buildObject().addBool('myBool', true).build())
+        .setValue(
+            'myJson', LDValue.buildObject().addBool('myBool', true).build())
         .build();
 
     expect(context.get('user', AttributeReference('/myJson/myBool')),
@@ -160,7 +162,7 @@ void main() {
     expect(
         LDContextBuilder()
             .kind('user', 'user-key')
-            .set('name', LDValue.ofString('bob'))
+            .setString('name', 'bob')
             .build()
             .attributesByKind['user']!
             .name,
@@ -171,7 +173,7 @@ void main() {
     expect(
         LDContextBuilder()
             .kind('user', 'user-key')
-            .set('name', LDValue.ofBool(false))
+            .setBool('name', false)
             .build()
             .attributesByKind['user']!
             .name,
@@ -182,7 +184,7 @@ void main() {
     expect(
         LDContextBuilder()
             .kind('user', 'user-key')
-            .set('anonymous', LDValue.ofBool(true))
+            .setBool('anonymous', true)
             .build()
             .attributesByKind['user']!
             .anonymous,
@@ -193,7 +195,7 @@ void main() {
     expect(
         LDContextBuilder()
             .kind('user', 'user-key')
-            .set('anonymous', LDValue.ofString('true'))
+            .setString('anonymous', 'true')
             .build()
             .attributesByKind['user']!
             .anonymous,
@@ -203,8 +205,8 @@ void main() {
   test('can set private attributes using setPrivate', () {
     final context = LDContextBuilder()
         .kind('org', 'org-key')
-        .setPrivate('custom1', LDValue.ofString('test'))
-        .setPrivate('/cus~tom/', LDValue.ofString('test'))
+        .setString('custom1', 'test', private: true)
+        .setString('/cus~tom/', 'test', private: true)
         .build();
 
     final attributes = context.attributesByKind['org'];
@@ -237,9 +239,11 @@ void main() {
   test('can get attributes by kind', () {
     final context = LDContextBuilder()
         .kind('zoo', 'zoo-key:%')
-        .set('a', LDValue.ofString('b'))
+        .setString('a', 'b')
         .kind('organization', 'org-key%:')
-        .set('a', LDValue.ofNum(42))
+        .setNum('a', 42)
+        .setValue(
+            'custom', LDValue.buildObject().addBool('poweruser', true).build())
         .build();
 
     expect(
@@ -255,8 +259,8 @@ void main() {
     expect(
         LDContextBuilder()
             .kind('user', 'bob')
-            .set('test', LDValue.ofString('test'))
-            .set('test', LDValue.ofNull())
+            .setString('test', 'test')
+            .setValue('test', LDValue.ofNull())
             .build()
             .attributesByKind['user']!
             .customAttributes['test'],
@@ -267,12 +271,12 @@ void main() {
     final context = LDContextBuilder()
         .kind('user', 'bob')
         .name('Bobby Person')
-        .setPrivate('email', LDValue.ofString('example@example.example'))
+        .setString('email', 'example@example.example', private: true)
         .anonymous(true)
         .kind('zoo', 'zoo-key:%')
-        .set('a', LDValue.ofString('b'))
+        .setString('a', 'b')
         .kind('organization', 'org-key%:')
-        .set('a', LDValue.ofNum(42))
+        .setNum('a', 42)
         .addPrivateAttributes(['a']).build();
 
     final context2 = LDContextBuilder.fromContext(context).build();

--- a/packages/common/test/serialization/event_serialization_test.dart
+++ b/packages/common/test/serialization/event_serialization_test.dart
@@ -32,7 +32,7 @@ void main() {
         context: LDContextBuilder()
             .kind('user', 'user-key')
             .name('the-name')
-            .set('custom', LDValue.ofString('custom'))
+            .setString('custom', 'custom')
             .build());
 
     final json = jsonEncode(IdentifyEventSerialization.toJson(event,
@@ -59,7 +59,7 @@ void main() {
         context: LDContextBuilder()
             .kind('user', 'user-key')
             .name('the-name')
-            .set('custom', LDValue.ofString('custom'))
+            .setString('custom', 'custom')
             .build());
 
     final json = jsonEncode(IdentifyEventSerialization.toJson(event,
@@ -321,7 +321,7 @@ void main() {
         context: LDContextBuilder()
             .kind('user', 'user-key')
             .name('the-name')
-            .set('custom', LDValue.ofString('custom'))
+            .setString('custom', 'custom')
             .build(),
         flagKey: 'the-flag',
         defaultValue: LDValue.ofString('default-value'),
@@ -363,7 +363,7 @@ void main() {
         context: LDContextBuilder()
             .kind('user', 'user-key')
             .name('the-name')
-            .set('custom', LDValue.ofString('custom'))
+            .setString('custom', 'custom')
             .build(),
         flagKey: 'the-flag',
         defaultValue: LDValue.ofString('default-value'),

--- a/packages/common/test/serialization/ld_context_serialization_test.dart
+++ b/packages/common/test/serialization/ld_context_serialization_test.dart
@@ -11,43 +11,43 @@ void main() {
   group('given single kind contexts', () {
     final basicContext = LDContextBuilder()
         .kind('organization', 'abc')
-        .set('firstName', LDValue.ofString('Sue'))
-        .set('bizzle', LDValue.ofString('def'))
-        .set('dizzle', LDValue.ofString('hgi'))
+        .setString('firstName', 'Sue')
+        .setString('bizzle', 'def')
+        .setString('dizzle', 'hgi')
         .build();
 
     final contextWithName = LDContextBuilder()
         .kind('organization', 'abc')
         .name('Name')
-        .set('firstName', LDValue.ofString('Sue'))
-        .set('bizzle', LDValue.ofString('def'))
-        .set('dizzle', LDValue.ofString('hgi'))
+        .setString('firstName', 'Sue')
+        .setString('bizzle', 'def')
+        .setString('dizzle', 'hgi')
         .build();
 
     final contextSpecifyingOwnPrivateAttr = LDContextBuilder()
         .kind('organization', 'abc')
-        .set('firstName', LDValue.ofString('Sue'))
-        .set('bizzle', LDValue.ofString('def'))
-        .set('dizzle', LDValue.ofString('hgi'))
+        .setString('firstName', 'Sue')
+        .setString('bizzle', 'def')
+        .setString('dizzle', 'hgi')
         .addPrivateAttributes(['dizzle', 'unused']).build();
 
     final anonymousContext = LDContextBuilder()
         .kind('organization', 'abc')
         .anonymous(true)
-        .set('firstName', LDValue.ofString('Sue'))
-        .set('bizzle', LDValue.ofString('def'))
-        .set('dizzle', LDValue.ofString('hgi'))
+        .setString('firstName', 'Sue')
+        .setString('bizzle', 'def')
+        .setString('dizzle', 'hgi')
         .build();
 
     final contextWithJsonAttribute = LDContextBuilder()
         .kind('organization', 'abc')
-        .set(
+        .setValue(
             'address',
             LDValueObjectBuilder()
                 .addString('city', 'FakeCity')
                 .addString('street', '123 Fake St.')
                 .build())
-        .set(
+        .setValue(
             'l1',
             LDValueObjectBuilder()
                 .addValue(
@@ -277,21 +277,22 @@ void main() {
   group('given a multi-kind context', () {
     final orgAndUserContext = LDContextBuilder()
         .kind('organization', 'LD')
-        .set('rocks', LDValue.ofBool(true))
+        .setBool('rocks', true)
         .name('name')
-        .set('department',
+        .setValue('department',
             LDValueObjectBuilder().addString('name', 'sdk').build())
         .kind('user', 'abc')
         .name('alphabet')
-        .setPrivate(
+        .setValue(
             'letters',
             LDValueArrayBuilder()
                 .addString('a')
                 .addString('b')
                 .addString('c')
-                .build())
-        .set('order', LDValue.ofNum(3))
-        .set(
+                .build(),
+            private: true)
+        .setNum('order', 3)
+        .setValue(
             'object',
             LDValueObjectBuilder()
                 .addString('a', 'a')

--- a/packages/common_client/lib/src/context_modifiers/env_context_modifier.dart
+++ b/packages/common_client/lib/src/context_modifiers/env_context_modifier.dart
@@ -128,8 +128,8 @@ class _ContextRecipe {
     // if any of the nodes are able to write themselves, include the version
     // and add the context
     if (wroteANode) {
-      attributesBuilder.set(AutoEnvConsts.envAttributesVersion,
-          LDValue.ofString(AutoEnvConsts.specVersion));
+      attributesBuilder.setString(
+          AutoEnvConsts.envAttributesVersion, AutoEnvConsts.specVersion);
       builder.mergeContext(singleContextBuilder.build());
     }
   }
@@ -192,6 +192,6 @@ class _LDAttributesBuilderAdapter implements _ISettableMap {
 
   @override
   void set(String attributeName, LDValue value) {
-    _underlyingBuilder.set(attributeName, value);
+    _underlyingBuilder.setValue(attributeName, value);
   }
 }

--- a/packages/common_client/test/context_decorators/env_context_modifier_test.dart
+++ b/packages/common_client/test/context_decorators/env_context_modifier_test.dart
@@ -331,7 +331,7 @@ void main() {
       contextBuilder.kind('user').name('Bob').anonymous(true);
       contextBuilder
           .kind('ld_application', 'fakeKey')
-          .set('myCoolAttribute', LDValue.ofString('myCoolValue'));
+          .setString('myCoolAttribute', 'myCoolValue');
       final context = contextBuilder.build();
       final decorator = AutoEnvContextModifier(report, mockPersistence, logger);
       final decoratedContext = await decorator.decorate(context);


### PR DESCRIPTION
Adds primitive type setters to the context builder API to make it more user friendly.

**Related issues**

https://app.shortcut.com/launchdarkly/story/222279/make-the-api-for-contexts-and-values-more-uniform-ideally-with-specific-typed-methods-in-addition-to-an-ldvalue-accepting