### PR TITLE
chore: Use generic updater for example updates instead of yaml updater.

### DIFF
--- a/packages/flutter_client_sdk/example/pubspec.yaml
+++ b/packages/flutter_client_sdk/example/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   # This defaults to a published package. Using `flutter pub get` will get the package from pub.dev
   # If you run `melos bs` in the root of the repository, then it will be linked to the local version
   # instead.
-  launchdarkly_flutter_client_sdk: 4.0.0-alpha.1
+  launchdarkly_flutter_client_sdk: 4.0.0-alpha.1 # x-release-please-version
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,11 +18,7 @@
       "include-component-in-tag": false,
       "extra-files": [
         "lib/src/ld_client.dart",
-        {
-          "type": "yaml",
-          "path": "example/pubspec.yaml",
-          "jsonpath": "$.dependencies.launchdarkly_flutter_client_sdk"
-        }
+        "example/pubspec.yaml"
       ]
     }
   },


### PR DESCRIPTION
The yaml updater removes all comments, so we want to use the generic updater instead.