### PR TITLE
fix: Decrease package_info_plus version requirements.

### DIFF
--- a/packages/flutter_client_sdk/pubspec.yaml
+++ b/packages/flutter_client_sdk/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  package_info_plus: ^5.0.1
+  package_info_plus: ">=4.2.0 <6.0.0"
   device_info_plus: ^9.1.1
   launchdarkly_common_client: 1.0.2
   shared_preferences: ^2.2.2


### PR DESCRIPTION
This reduces the required version of `package_info_plus` in order to allow for older flutter/dart targets.