### PR TITLE
fix: backgrounded and offline apps no longer attempt to send events

### DIFF
--- a/packages/flutter_client_sdk/lib/src/connection_manager.dart
+++ b/packages/flutter_client_sdk/lib/src/connection_manager.dart
@@ -179,7 +179,6 @@ final class ConnectionManager {
     /// If connections in the background are allowed, then use the same mode
     /// as is configured for the foreground.
     _setForegroundAvailableMode();
-    _destination.setEventSendingEnabled(true);
   }
 
   void _handleState() {


### PR DESCRIPTION
`setEventSendingEnabled` was handled in `_setForegroundAvailableMode`