### PR TITLE
chore: Add the startWithTimeout method to ensure a timeout is used

### DIFF
--- a/packages/common_client/lib/src/ld_common_client.dart
+++ b/packages/common_client/lib/src/ld_common_client.dart
@@ -172,6 +172,20 @@ final class LDCommonClient {
         context);
   }
 
+  /// This is the new method that will enforce a timeout is passed to the future.
+  ///
+  /// If the return value is true, then the SDK has initialized, if false
+  /// then the SDK has encountered an unrecoverable error. If
+  Future<bool> startWithTimeout(Duration timeout) {
+    if (timeout > Duration(seconds: 15)) {
+      _logger.warn(
+          'The method startWithTimeout was called with a timeout greater than 15 seconds. '
+          'We recommend a timeout of less than 15 seconds.');
+    }
+
+    return start().timeout(timeout);
+  }
+
   /// This instructs the SDK to start connecting to LaunchDarkly. Ideally
   /// this is called before any other methods. Variation calls before the SDK
   /// has been started, or after starting but before initialization is complete,

--- a/packages/common_client/test/ld_dart_client_test.dart
+++ b/packages/common_client/test/ld_dart_client_test.dart
@@ -25,8 +25,17 @@ void main() {
           DiagnosticSdkData(name: '', version: ''));
     });
 
+    test('client can start successfully with a timeout', () async {
+      expect(await client.startWithTimeout(const Duration(seconds: 90)), true);
+    });
+
     test('client can start successfully', () async {
       expect(await client.start(), true);
+    });
+
+    test('client reports initialized after startWithTimeout', () async {
+      await client.startWithTimeout(const Duration(seconds: 90));
+      expect(client.initialized, isTrue);
     });
 
     test('client reports initialized after start', () async {

--- a/packages/flutter_client_sdk/lib/src/ld_client.dart
+++ b/packages/flutter_client_sdk/lib/src/ld_client.dart
@@ -89,6 +89,10 @@ interface class LDClient {
         detector: FlutterStateDetector());
   }
 
+  Future<bool> startWithTimeout(Duration timeout) async {
+    return _client.startWithTimeout(timeout);
+  }
+
   /// Initialize the SDK.
   ///
   /// This should be called before using the SDK to evaluate flags. Note that


### PR DESCRIPTION
Because the current start method returns a future, to not create behavioral change, it probably makes sense to create a new method to use.