### PR TITLE
feat: Add support for waiting for non-cached values.

### DIFF
--- a/packages/common_client/lib/src/data_sources/data_source_manager.dart
+++ b/packages/common_client/lib/src/data_sources/data_source_manager.dart
@@ -41,7 +41,7 @@ final class DataSourceManager {
         _dataSourceEventHandler = dataSourceEventHandler;
 
   /// Set the available data source factories. These factories will not apply
-  /// until the next identify fall. Currently factories will be set once during
+  /// until the next identify call. Currently factories will be set once during
   /// startup and before the first identify.
   void setFactories(Map<ConnectionMode, DataSourceFactory> factories) {
     _dataSourceFactories.clear();

--- a/packages/common_client/lib/src/ld_common_client.dart
+++ b/packages/common_client/lib/src/ld_common_client.dart
@@ -203,7 +203,7 @@ final class LDCommonClient {
 
   Future<void> _setAndDecorateContext(LDContext context) async {
     _context = await _modifiers.asyncReduce(
-            (reducer, accumulator) async => await reducer.decorate(accumulator),
+        (reducer, accumulator) async => await reducer.decorate(accumulator),
         context);
   }
 
@@ -247,12 +247,12 @@ final class LDCommonClient {
       case IdentifyComplete():
         return true;
       case IdentifySuperseded():
-      // This case does not happen because of the queue configuration. First
-      // item in the queue will always be the start identify and it will
-      // always be executed.
+        // This case does not happen because of the queue configuration. First
+        // item in the queue will always be the start identify and it will
+        // always be executed.
         _logger.error(
             'Identify was superseded, this represents a logic error in the SDK '
-                'implementation. Please file a bug report.');
+            'implementation. Please file a bug report.');
         continue error; // Simulate fallthrough.
       error:
       case IdentifyError():
@@ -296,7 +296,7 @@ final class LDCommonClient {
               .where((ref) => ref.valid)
               .toSet(),
           diagnosticRecordingInterval:
-          _config.events.diagnosticRecordingInterval);
+              _config.events.diagnosticRecordingInterval);
     }
 
     _updateEventSendingState();
@@ -320,40 +320,40 @@ final class LDCommonClient {
     final diagnosticsManager = _config.events.diagnosticOptOut
         ? null
         : DiagnosticsManager(
-        credential: _config.sdkCredential,
-        sdkData: _sdkData,
-        platformData: DiagnosticPlatformData(
-          name: 'Dart',
-          osName: osInfo?.name,
-          osVersion: osInfo?.version,
-        ),
-        configData: DiagnosticConfigData(
-            customBaseUri: _config.serviceEndpoints.polling !=
-                _config.serviceEndpoints.defaultPolling,
-            customStreamUri: _config.serviceEndpoints.streaming !=
-                _config.serviceEndpoints.streaming,
-            eventsCapacity: _config.events.eventCapacity,
-            connectTimeoutMillis:
-            _config.httpProperties.connectTimeout.inMilliseconds,
-            eventsFlushIntervalMillis:
-            _config.events.flushInterval.inMilliseconds,
-            pollingIntervalMillis: _config
-                .dataSourceConfig.polling.pollingInterval.inMilliseconds,
-            // TODO: If made dynamic, then needs implemented.
-            reconnectTimeoutMillis: 1000,
-            // For now disabled means polling is enabled. When dynamic
-            // switching is added, then this can potentially just return
-            // `false`.
-            streamingDisabled:
-            _config.dataSourceConfig.initialConnectionMode ==
-                ConnectionMode.polling,
-            offline: _config.offline,
-            allAttributesPrivate: _config.allAttributesPrivate,
-            diagnosticRecordingIntervalMillis:
-            _config.events.diagnosticRecordingInterval.inMilliseconds,
-            useReport: _config.dataSourceConfig.useReport,
-            evaluationReasonsRequested:
-            _config.dataSourceConfig.evaluationReasons));
+            credential: _config.sdkCredential,
+            sdkData: _sdkData,
+            platformData: DiagnosticPlatformData(
+              name: 'Dart',
+              osName: osInfo?.name,
+              osVersion: osInfo?.version,
+            ),
+            configData: DiagnosticConfigData(
+                customBaseUri: _config.serviceEndpoints.polling !=
+                    _config.serviceEndpoints.defaultPolling,
+                customStreamUri: _config.serviceEndpoints.streaming !=
+                    _config.serviceEndpoints.streaming,
+                eventsCapacity: _config.events.eventCapacity,
+                connectTimeoutMillis:
+                    _config.httpProperties.connectTimeout.inMilliseconds,
+                eventsFlushIntervalMillis:
+                    _config.events.flushInterval.inMilliseconds,
+                pollingIntervalMillis: _config
+                    .dataSourceConfig.polling.pollingInterval.inMilliseconds,
+                // TODO: If made dynamic, then needs implemented.
+                reconnectTimeoutMillis: 1000,
+                // For now disabled means polling is enabled. When dynamic
+                // switching is added, then this can potentially just return
+                // `false`.
+                streamingDisabled:
+                    _config.dataSourceConfig.initialConnectionMode ==
+                        ConnectionMode.polling,
+                offline: _config.offline,
+                allAttributesPrivate: _config.allAttributesPrivate,
+                diagnosticRecordingIntervalMillis:
+                    _config.events.diagnosticRecordingInterval.inMilliseconds,
+                useReport: _config.dataSourceConfig.useReport,
+                evaluationReasonsRequested:
+                    _config.dataSourceConfig.evaluationReasons));
     return diagnosticsManager;
   }
 
@@ -419,7 +419,7 @@ final class LDCommonClient {
   /// Will return the provided [defaultValue] if the flag is missing, not a bool, or if some error occurs.
   bool boolVariation(String flagKey, bool defaultValue) {
     return _variationInternal(flagKey, LDValue.ofBool(defaultValue),
-        isDetailed: false, type: LDValueType.boolean)
+            isDetailed: false, type: LDValueType.boolean)
         .value
         .booleanValue();
   }
@@ -428,8 +428,8 @@ final class LDCommonClient {
   ///
   /// See [LDEvaluationDetail] for more information on the returned value. Note that [DataSourceConfig.evaluationReasons]
   /// must have been set to `true` to request the additional evaluation information from the backend.
-  LDEvaluationDetail<bool> boolVariationDetail(String flagKey,
-      bool defaultValue) {
+  LDEvaluationDetail<bool> boolVariationDetail(
+      String flagKey, bool defaultValue) {
     final ldValueVariation = _variationInternal(
         flagKey, LDValue.ofBool(defaultValue),
         isDetailed: true, type: LDValueType.boolean);
@@ -443,7 +443,7 @@ final class LDCommonClient {
   /// Will return the provided [defaultValue] if the flag is missing, not a number, or if some error occurs.
   int intVariation(String flagKey, int defaultValue) {
     return _variationInternal(flagKey, LDValue.ofNum(defaultValue),
-        isDetailed: false, type: LDValueType.number)
+            isDetailed: false, type: LDValueType.number)
         .value
         .intValue();
   }
@@ -466,7 +466,7 @@ final class LDCommonClient {
   /// Will return the provided [defaultValue] if the flag is missing, not a number, or if some error occurs.
   double doubleVariation(String flagKey, double defaultValue) {
     return _variationInternal(flagKey, LDValue.ofNum(defaultValue),
-        isDetailed: false, type: LDValueType.number)
+            isDetailed: false, type: LDValueType.number)
         .value
         .doubleValue();
   }
@@ -475,8 +475,8 @@ final class LDCommonClient {
   ///
   /// See [LDEvaluationDetail] for more information on the returned value. Note that [DataSourceConfig.evaluationReasons]
   /// must have been set to `true` to request the additional evaluation information from the backend.
-  LDEvaluationDetail<double> doubleVariationDetail(String flagKey,
-      double defaultValue) {
+  LDEvaluationDetail<double> doubleVariationDetail(
+      String flagKey, double defaultValue) {
     final ldValueVariation = _variationInternal(
         flagKey, LDValue.ofNum(defaultValue),
         isDetailed: true, type: LDValueType.number);
@@ -490,7 +490,7 @@ final class LDCommonClient {
   /// Will return the provided [defaultValue] if the flag is missing, not a string, or if some error occurs.
   String stringVariation(String flagKey, String defaultValue) {
     return _variationInternal(flagKey, LDValue.ofString(defaultValue),
-        isDetailed: false, type: LDValueType.string)
+            isDetailed: false, type: LDValueType.string)
         .value
         .stringValue();
   }
@@ -500,8 +500,8 @@ final class LDCommonClient {
   ///
   /// See [LDEvaluationDetail] for more information on the returned value. Note that [DataSourceConfig.evaluationReasons]
   /// must have been set to `true` to request the additional evaluation information from the backend.
-  LDEvaluationDetail<String> stringVariationDetail(String flagKey,
-      String defaultValue) {
+  LDEvaluationDetail<String> stringVariationDetail(
+      String flagKey, String defaultValue) {
     final ldValueVariation = _variationInternal(
         flagKey, LDValue.ofString(defaultValue),
         isDetailed: true, type: LDValueType.string);
@@ -521,13 +521,13 @@ final class LDCommonClient {
   ///
   /// See [LDEvaluationDetail] for more information on the returned value. Note that [DataSourceConfig.evaluationReasons]
   /// must have been set to `true` to request the additional evaluation information from the backend.
-  LDEvaluationDetail<LDValue> jsonVariationDetail(String flagKey,
-      LDValue defaultValue) {
+  LDEvaluationDetail<LDValue> jsonVariationDetail(
+      String flagKey, LDValue defaultValue) {
     return _variationInternal(flagKey, defaultValue, isDetailed: true);
   }
 
-  LDEvaluationDetail<LDValue> _variationInternal(String flagKey,
-      LDValue defaultValue,
+  LDEvaluationDetail<LDValue> _variationInternal(
+      String flagKey, LDValue defaultValue,
       {required bool isDetailed, LDValueType? type}) {
     final evalResult = _flagManager.get(flagKey);
 
@@ -555,7 +555,7 @@ final class LDCommonClient {
         trackEvent: evalResult?.flag?.trackEvents ?? false,
         debugEventsUntilDate: evalResult?.flag?.debugEventsUntilDate != null
             ? DateTime.fromMillisecondsSinceEpoch(
-            evalResult!.flag!.debugEventsUntilDate!)
+                evalResult!.flag!.debugEventsUntilDate!)
             : null,
         version: evalResult?.version));
 
@@ -572,7 +572,7 @@ final class LDCommonClient {
     final allEvalResults = _flagManager.getAll();
 
     for (var MapEntry(key: flagKey, value: evalResult)
-    in allEvalResults.entries) {
+        in allEvalResults.entries) {
       if (evalResult.flag != null) {
         res[flagKey] = evalResult.flag!.detail.value;
       }

--- a/packages/common_client/lib/src/ld_common_client.dart
+++ b/packages/common_client/lib/src/ld_common_client.dart
@@ -45,9 +45,11 @@ final class IdentifyError implements IdentifyResult {
   IdentifyError(this.error);
 }
 
-typedef DataSourceFactoriesFn = Map<ConnectionMode, DataSourceFactory> Function(LDCommonConfig config, LDLogger logger, HttpProperties httpProperties);
+typedef DataSourceFactoriesFn = Map<ConnectionMode, DataSourceFactory> Function(
+    LDCommonConfig config, LDLogger logger, HttpProperties httpProperties);
 
-Map<ConnectionMode, DataSourceFactory> _defaultFactories(LDCommonConfig config, LDLogger logger, HttpProperties httpProperties) {
+Map<ConnectionMode, DataSourceFactory> _defaultFactories(
+    LDCommonConfig config, LDLogger logger, HttpProperties httpProperties) {
   return {
     ConnectionMode.streaming: (LDContext context) {
       return StreamingDataSource(
@@ -69,8 +71,7 @@ Map<ConnectionMode, DataSourceFactory> _defaultFactories(LDCommonConfig config, 
           dataSourceConfig: PollingDataSourceConfig(
               useReport: config.dataSourceConfig.useReport,
               withReasons: config.dataSourceConfig.evaluationReasons,
-              pollingInterval:
-              config.dataSourceConfig.polling.pollingInterval),
+              pollingInterval: config.dataSourceConfig.polling.pollingInterval),
           httpProperties: httpProperties);
     },
   };
@@ -234,7 +235,8 @@ final class LDCommonClient {
     // having been set resulting in a crash.
     _identifyQueue.execute(() async {
       await _startInternal();
-      await _identifyInternal(_initialUndecoratedContext, waitForNonCachedValues: waitForNonCachedValues);
+      await _identifyInternal(_initialUndecoratedContext,
+          waitForNonCachedValues: waitForNonCachedValues);
     }).then((res) {
       _startCompleter!.complete(_mapIdentifyResult(res));
     });
@@ -302,8 +304,8 @@ final class LDCommonClient {
     _updateEventSendingState();
 
     if (!_config.offline) {
-      _dataSourceManager.setFactories(
-          _dataSourceFactories(_config, _logger, httpProperties));
+      _dataSourceManager
+          .setFactories(_dataSourceFactories(_config, _logger, httpProperties));
     } else {
       _dataSourceManager.setFactories({
         ConnectionMode.streaming: (LDContext context) {

--- a/packages/common_client/test/ld_dart_client_test.dart
+++ b/packages/common_client/test/ld_dart_client_test.dart
@@ -244,7 +244,7 @@ void main() {
       await client.start();
 
       await client.identify(LDContextBuilder().kind('user', 'joe').build(),
-          waitForNonCachedValues: true);
+          waitForNetworkResults: true);
       final res = client.stringVariation('flagA', 'default');
       expect(res, 'datasource');
     });
@@ -278,7 +278,7 @@ void main() {
             '}}'
       };
 
-      await client.start(waitForNonCachedValues: true);
+      await client.start(waitForNetworkResults: true);
       final res = client.stringVariation('flagA', 'default');
       expect(res, 'datasource');
     });

--- a/packages/common_client/test/ld_dart_client_test.dart
+++ b/packages/common_client/test/ld_dart_client_test.dart
@@ -251,7 +251,7 @@ void main() {
 
     test('start can resolve cached values', () async {
       final contextPersistenceKey =
-      sha256.convert(utf8.encode('bob')).toString();
+          sha256.convert(utf8.encode('bob')).toString();
       mockPersistence.storage[sdkKeyPersistence] = {
         contextPersistenceKey: '{"flagA":{'
             '"version":1,'
@@ -268,7 +268,7 @@ void main() {
 
     test('start can resolve non-cached values', () async {
       final contextPersistenceKey =
-      sha256.convert(utf8.encode('bob')).toString();
+          sha256.convert(utf8.encode('bob')).toString();
       mockPersistence.storage[sdkKeyPersistence] = {
         contextPersistenceKey: '{"flagA":{'
             '"version":1,'

--- a/packages/common_client/test/ld_dart_client_test.dart
+++ b/packages/common_client/test/ld_dart_client_test.dart
@@ -24,7 +24,6 @@ final class TestDataSource implements DataSource {
   final StreamController<DataSourceEvent> _eventController = StreamController();
 
   @override
-  // TODO: implement events
   Stream<DataSourceEvent> get events => _eventController.stream;
 
   @override

--- a/packages/flutter_client_sdk/lib/src/ld_client.dart
+++ b/packages/flutter_client_sdk/lib/src/ld_client.dart
@@ -117,7 +117,6 @@ interface class LDClient {
   ///
   /// If [waitForNetworkResults] is true, and an error is encountered, then
   /// false may be returned even if cached values were loaded.
-  /// false may be returned even if cached values were loaded.
   Future<bool> start({bool waitForNetworkResults = false}) async {
     return _client.start(waitForNetworkResults: waitForNetworkResults);
   }

--- a/packages/flutter_client_sdk/lib/src/ld_client.dart
+++ b/packages/flutter_client_sdk/lib/src/ld_client.dart
@@ -107,8 +107,15 @@ interface class LDClient {
   /// ```dart
   /// await client.start().timeout(const Duration(seconds: 30));
   /// ```
-  Future<bool> start() async {
-    return _client.start();
+  /// The [waitForNonCachedValues] parameters, when true, indicates that the SDK
+  /// will attempt to wait for values from LaunchDarkly instead of depending
+  /// on cached values. The cached values will still be loaded, but the future
+  /// returned by this function will not resolve. Generally this
+  /// option should NOT be used and instead flag changes should be listened to.
+  /// If [waitForNonCachedValues] is true, and an error is encountered, then
+  /// false may be returned even if cached values were loaded.
+  Future<bool> start({bool waitForNonCachedValues = false}) async {
+    return _client.start(waitForNonCachedValues: waitForNonCachedValues);
   }
 
   /// Changes the active context.
@@ -119,9 +126,20 @@ interface class LDClient {
   /// service containing the public [LDContext] fields for indexing on the
   /// dashboard.
   ///
+  /// A context with the same kinds and same keys will use the same cached
+  /// context.
+  ///
   /// This returned future can be awaited to wait for the identify process to
   /// be complete. As with [start] this can take an extended period if there
   /// is not network availability, so a timeout is recommended.
+  ///
+  /// The [waitForNonCachedValues] parameters, when true, indicates that the SDK
+  /// will attempt to wait for values from LaunchDarkly instead of depending
+  /// on cached values. The cached values will still be loaded, but the future
+  /// returned by this function will not resolve. Generally this
+  /// option should NOT be used and instead flag changes should be listened to.
+  /// If [waitForNonCachedValues] is true, and an error is encountered, then
+  /// [IdentifyError] may be returned even if cached values were loaded.
   ///
   /// The identify will complete with 1 of three possible values:
   /// [IdentifyComplete], [IdentifySuperseded], or [IdentifyError].
@@ -139,8 +157,8 @@ interface class LDClient {
   ///
   /// [IdentifyError] this means that the identify has permanently failed. For
   /// instance the SDK key is no longer valid.
-  Future<IdentifyResult> identify(LDContext context) async {
-    return _client.identify(context);
+  Future<IdentifyResult> identify(LDContext context, {bool waitForNonCachedValues = false}) async {
+    return _client.identify(context, waitForNonCachedValues: waitForNonCachedValues);
   }
 
   /// Track custom events associated with the current context for data export or

--- a/packages/flutter_client_sdk/lib/src/ld_client.dart
+++ b/packages/flutter_client_sdk/lib/src/ld_client.dart
@@ -107,15 +107,19 @@ interface class LDClient {
   /// ```dart
   /// await client.start().timeout(const Duration(seconds: 30));
   /// ```
-  /// The [waitForNonCachedValues] parameters, when true, indicates that the SDK
+  /// The [waitForNetworkResults] parameters, when true, indicates that the SDK
   /// will attempt to wait for values from LaunchDarkly instead of depending
   /// on cached values. The cached values will still be loaded, but the future
-  /// returned by this function will not resolve. Generally this
-  /// option should NOT be used and instead flag changes should be listened to.
-  /// If [waitForNonCachedValues] is true, and an error is encountered, then
+  /// returned by this function will not resolve as a result of those cached
+  /// values being loaded. Generally this option should NOT be used and instead
+  /// flag changes should be listened to. It the client is set to offline mode,
+  /// then this option is ignored.
+  ///
+  /// If [waitForNetworkResults] is true, and an error is encountered, then
   /// false may be returned even if cached values were loaded.
-  Future<bool> start({bool waitForNonCachedValues = false}) async {
-    return _client.start(waitForNonCachedValues: waitForNonCachedValues);
+  /// false may be returned even if cached values were loaded.
+  Future<bool> start({bool waitForNetworkResults = false}) async {
+    return _client.start(waitForNetworkResults: waitForNetworkResults);
   }
 
   /// Changes the active context.
@@ -133,12 +137,15 @@ interface class LDClient {
   /// be complete. As with [start] this can take an extended period if there
   /// is not network availability, so a timeout is recommended.
   ///
-  /// The [waitForNonCachedValues] parameters, when true, indicates that the SDK
+  /// The [waitForNetworkResults] parameters, when true, indicates that the SDK
   /// will attempt to wait for values from LaunchDarkly instead of depending
   /// on cached values. The cached values will still be loaded, but the future
-  /// returned by this function will not resolve. Generally this
-  /// option should NOT be used and instead flag changes should be listened to.
-  /// If [waitForNonCachedValues] is true, and an error is encountered, then
+  /// returned by this function will not resolve as a result of those cached
+  /// values being loaded. Generally this option should NOT be used and instead
+  /// flag changes should be listened to. It the client is set to offline mode,
+  /// then this option is ignored.
+  ///
+  /// If [waitForNetworkResults] is true, and an error is encountered, then
   /// [IdentifyError] may be returned even if cached values were loaded.
   ///
   /// The identify will complete with 1 of three possible values:
@@ -158,9 +165,9 @@ interface class LDClient {
   /// [IdentifyError] this means that the identify has permanently failed. For
   /// instance the SDK key is no longer valid.
   Future<IdentifyResult> identify(LDContext context,
-      {bool waitForNonCachedValues = false}) async {
+      {bool waitForNetworkResults = false}) async {
     return _client.identify(context,
-        waitForNonCachedValues: waitForNonCachedValues);
+        waitForNetworkResults: waitForNetworkResults);
   }
 
   /// Track custom events associated with the current context for data export or

--- a/packages/flutter_client_sdk/lib/src/ld_client.dart
+++ b/packages/flutter_client_sdk/lib/src/ld_client.dart
@@ -157,8 +157,10 @@ interface class LDClient {
   ///
   /// [IdentifyError] this means that the identify has permanently failed. For
   /// instance the SDK key is no longer valid.
-  Future<IdentifyResult> identify(LDContext context, {bool waitForNonCachedValues = false}) async {
-    return _client.identify(context, waitForNonCachedValues: waitForNonCachedValues);
+  Future<IdentifyResult> identify(LDContext context,
+      {bool waitForNonCachedValues = false}) async {
+    return _client.identify(context,
+        waitForNonCachedValues: waitForNonCachedValues);
   }
 
   /// Track custom events associated with the current context for data export or


### PR DESCRIPTION
1. Allows for the common client to have customized data sources. This was used for testing here, but could be used for more specialized use-cases in the future.
2. Adds the ability for `start` and `identify` to wait for values from LaunchDarkly instead of resolving with cached values when available.

With the previous wrapper SDK this behavior was controlled by the underlying SDK and those would operate similar to the new, optional, behavior.

For most uses cases it is both safer and higher performance to used cached values when they are available instead of only using those cached values as a fallback.

Ideally we would add new return values to start and identify. Next major version we should consider:
`Cached`, `Timeout`. While retaining the current value for completing via data from LD.
