### PR TITLE
fix: Use correct flag version in evaluation events.

### DIFF
--- a/apps/flutter_client_contract_test_service/pubspec.lock
+++ b/apps/flutter_client_contract_test_service/pubspec.lock
@@ -398,7 +398,7 @@ packages:
       path: "../../packages/flutter_client_sdk"
       relative: true
     source: path
-    version: "4.6.0"
+    version: "4.7.0"
   lints:
     dependency: "direct dev"
     description:

--- a/packages/common/lib/src/ld_evaluation_result.dart
+++ b/packages/common/lib/src/ld_evaluation_result.dart
@@ -9,6 +9,9 @@ final class LDEvaluationResult {
   /// Incremented by LaunchDarkly each time the flag's state changes.
   final int version;
 
+  /// The version of the flag. Changes when modifications are made to the flag.
+  final int? flagVersion;
+
   ///  True if a client SDK should track events for this flag.
   final bool trackEvents;
 
@@ -24,6 +27,7 @@ final class LDEvaluationResult {
 
   const LDEvaluationResult(
       {required this.version,
+      this.flagVersion,
       required this.detail,
       this.trackEvents = false,
       this.trackReason = false,
@@ -31,8 +35,9 @@ final class LDEvaluationResult {
 
   @override
   String toString() {
-    return 'LDEvaluationResult{version: $version, trackEvents: $trackEvents, '
-        'trackReason: $trackReason, debugEventsUntilDate: $debugEventsUntilDate,'
+    return 'LDEvaluationResult{version: $version, flagVersion: $flagVersion,'
+        ' trackEvents: $trackEvents, trackReason: $trackReason,'
+        ' debugEventsUntilDate: $debugEventsUntilDate,'
         ' detail: $detail}';
   }
 
@@ -41,6 +46,7 @@ final class LDEvaluationResult {
       identical(this, other) ||
       other is LDEvaluationResult &&
           version == other.version &&
+          flagVersion == other.flagVersion &&
           trackEvents == other.trackEvents &&
           trackReason == other.trackReason &&
           debugEventsUntilDate == other.debugEventsUntilDate &&
@@ -49,6 +55,7 @@ final class LDEvaluationResult {
   @override
   int get hashCode =>
       version.hashCode ^
+      flagVersion.hashCode ^
       trackEvents.hashCode ^
       trackReason.hashCode ^
       debugEventsUntilDate.hashCode ^

--- a/packages/common/lib/src/serialization/ld_evaluation_result_serialization.dart
+++ b/packages/common/lib/src/serialization/ld_evaluation_result_serialization.dart
@@ -3,6 +3,7 @@ import '../../launchdarkly_dart_common.dart';
 final class LDEvaluationResultSerialization {
   static LDEvaluationResult fromJson(Map<String, dynamic> json) {
     final version = json['version'] as num;
+    final flagVersion = json['flagVersion'] as num?;
     final trackEvents = (json['trackEvents'] ?? false) as bool;
     final trackReason = (json['trackReason'] ?? false) as bool;
     final debugEventsUntilDateRaw = json['debugEventsUntilDate'] as num?;
@@ -19,6 +20,7 @@ final class LDEvaluationResultSerialization {
 
     return LDEvaluationResult(
         version: version.toInt(),
+        flagVersion: flagVersion?.toInt(),
         detail: LDEvaluationDetail(value, variationIndex, reason),
         trackEvents: trackEvents,
         trackReason: trackReason,

--- a/packages/common/test/ld_evaluation_result_test.dart
+++ b/packages/common/test/ld_evaluation_result_test.dart
@@ -61,13 +61,14 @@ void main() {
 
   test('it produces the expected string', () {
     final a = LDEvaluationResult(
-        version: 1,
+        version: 11,
+        flagVersion: 1,
         detail: LDEvaluationDetail<LDValue>(
             LDValue.ofString('toast'), null, LDEvaluationReason.targetMatch()));
 
     expect(
         a.toString(),
-        'LDEvaluationResult{version: 1, trackEvents: false, trackReason: false,'
+        'LDEvaluationResult{version: 11, flagVersion: 1, trackEvents: false, trackReason: false,'
         ' debugEventsUntilDate: null, detail: LDEvaluationDetail{value:'
         ' LDValue{_value: toast}, variationIndex: null, reason:'
         ' LDEvaluationReason{kind: TARGET_MATCH, ruleIndex: null,'

--- a/packages/common_client/lib/src/ld_common_client.dart
+++ b/packages/common_client/lib/src/ld_common_client.dart
@@ -551,7 +551,7 @@ final class LDCommonClient {
             ? DateTime.fromMillisecondsSinceEpoch(
                 evalResult!.flag!.debugEventsUntilDate!)
             : null,
-        version: evalResult?.version));
+        version: evalResult?.flag?.flagVersion ?? evalResult?.version));
 
     return detail;
   }

--- a/packages/common_client/test/ld_dart_client_test.dart
+++ b/packages/common_client/test/ld_dart_client_test.dart
@@ -35,7 +35,8 @@ final class TestDataSource implements DataSource {
       _eventController.sink.add(DataEvent(
           'put',
           '{"flagA":{'
-              '"version":1,'
+              '"version":11,'
+              '"flagVersion":1,'
               '"value":"datasource",'
               '"variation":0,'
               '"reason":{"kind":"OFF"}'


### PR DESCRIPTION
There is an associated change to the sdk-test harness to ensure we don't encounter this again.