### PR TITLE
feat: Add support for connectivity_plus 7.0+

### DIFF
--- a/packages/flutter_client_sdk/pubspec.yaml
+++ b/packages/flutter_client_sdk/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   device_info_plus: ">=9.1.1 <13.0.0"
   launchdarkly_common_client: 1.7.0
   shared_preferences: ^2.2.2
-  connectivity_plus: ">=5.0.2 <7.0.0"
+  connectivity_plus: ">=5.0.2 <8.0.0"
   web: ^1.1.1
 
 dev_dependencies:


### PR DESCRIPTION
Updates the version constraints to support connectivity plus 7.0+.

Similar to other plus library updates this is just a change to the build support tooling. It doesn't raise the minimum requirements of our SDK, but does raise them when using our SDK with connectivity plus 7.0+.

Fixes: #231 