### PR TITLE
feat: Update common-client library to 1.8.0

### DIFF
--- a/packages/flutter_client_sdk/lib/launchdarkly_flutter_client_sdk.dart
+++ b/packages/flutter_client_sdk/lib/launchdarkly_flutter_client_sdk.dart
@@ -54,7 +54,8 @@ export 'package:launchdarkly_common_client/launchdarkly_common_client.dart'
         PluginSdkMetadata,
         PluginCredentialInfo,
         PluginEnvironmentMetadata,
-        PluginMetadata;
+        PluginMetadata,
+        PollingConfig;
 
 export 'src/ld_client.dart' show LDClient;
 export 'src/config/ld_config.dart' show LDConfig, ApplicationEvents;

--- a/packages/flutter_client_sdk/pubspec.yaml
+++ b/packages/flutter_client_sdk/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   package_info_plus: ">=4.2.0 <10.0.0"
   device_info_plus: ">=9.1.1 <13.0.0"
-  launchdarkly_common_client: 1.7.0
+  launchdarkly_common_client: 1.8.0
   shared_preferences: ^2.2.2
   connectivity_plus: ">=5.0.2 <8.0.0"
   web: ^1.1.1


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: Update to launchdarkly_common_client 1.8.0
feat: Add support for ping stream.
fix: Expose polling configuration type.
END_COMMIT_OVERRIDE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose `PollingConfig` in the Flutter SDK public API and bump `launchdarkly_common_client` to 1.8.0.
> 
> - **API surface**:
>   - Export `PollingConfig` from `launchdarkly_common_client` in `packages/flutter_client_sdk/lib/launchdarkly_flutter_client_sdk.dart`.
> - **Dependencies**:
>   - Bump `launchdarkly_common_client` to `1.8.0` in `packages/flutter_client_sdk/pubspec.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 318769dcb96a61fa5617109f48391d5d5d44e827. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->