### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -21,12 +21,12 @@ runs:
   using: composite
   steps:
     - name: Install Dart
-      uses: dart-lang/setup-dart@v1
+      uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
       with:
         sdk: ${{ inputs.dart_version }}
 
     - name: Install Flutter
-      uses: subosito/flutter-action@v2
+      uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295 # v2
       with:
         flutter-version: ${{ inputs.flutter_version }}
         channel: 'stable'

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -10,12 +10,12 @@ runs:
   using: composite
   steps:
     - name: Install Dart
-      uses: dart-lang/setup-dart@v1
+      uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
       with:
         sdk: '3.7.2'
 
     - name: Install Flutter
-      uses: subosito/flutter-action@v2
+      uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295 # v2
       with:
         flutter-version: '3.29.3'
         channel: 'stable'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: "/production/common/releasing/flutter_gh_pat = GITHUB_PAT"
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3
         id: release
         with:
           command: manifest


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs to prevent supply chain attacks.

Addresses findings from the [`third-party-action-not-pinned-to-commit-sha`](https://github.com/launchdarkly/semgrep-rules/blob/main/github-actions/third-party-action-not-pinned-to-commit-sha.yml) Semgrep rule.

## Test plan

- [ ] Verify CI passes with pinned action SHAs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI/release workflow changes only, swapping tag-based action references for pinned SHAs; main risk is breakage if the pinned commits are incorrect or later revoked.
> 
> **Overview**
> Pins third-party GitHub Actions used by the shared CI and publish composites and the `release-please` workflow from floating tags (e.g. `@v1`, `@v2`, `@v3`) to full commit SHAs.
> 
> This reduces supply-chain risk by ensuring CI/release runs use immutable action revisions, without changing the workflow logic or inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d7eb6670d6caff6be9299f69b3f8a82021239e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->