### PR TITLE
chore: add Claude Code configuration

### DIFF
--- a/.claude/hooks/stop-lint-test.sh
+++ b/.claude/hooks/stop-lint-test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Stop hook: block session end until `melos run analyze` and `melos run test` pass.
+# Reads Claude Code's Stop-hook JSON on stdin. Exit 2 tells Claude to keep going;
+# stderr is surfaced back to the model as the reason.
+
+set -u
+
+input=$(cat)
+
+if [ "$(printf '%s' "$input" | jq -r '.stop_hook_active // false')" = "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(dirname "$0")/../..}" || {
+  echo "stop-lint-test.sh: could not cd to project root" >&2
+  exit 2
+}
+
+if ! analyze_output=$(melos run analyze 2>&1); then
+  printf '%s\n\nmelos run analyze failed — fix analyzer errors before ending the task.\n' "$analyze_output" >&2
+  exit 2
+fi
+
+if ! test_output=$(melos run test 2>&1); then
+  printf '%s\n\nmelos run test failed — fix failing tests before ending the task.\n' "$test_output" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/stop-lint-test.sh\"",
+            "timeout": 900,
+            "statusMessage": "Running melos analyze + test before stopping..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository layout
+
+This is a [Melos](https://github.com/invertase/melos)-managed Dart/Flutter monorepo that publishes `launchdarkly_flutter_client_sdk` along with its supporting packages.
+
+- `packages/common` (`launchdarkly_dart_common`) — Dart-only code usable by both client-side and server-side SDKs (contexts, `LDValue`, logging, events, env reporting, serialization, network helpers).
+- `packages/common_client` (`launchdarkly_common_client`) — client-side SDK code that is not Flutter-specific (flag manager, data sources, hooks, plugins, persistence interface, `LDCommonClient`).
+- `packages/event_source_client` (`launchdarkly_event_source_client`) — SSE client implementation used by the streaming data source.
+- `packages/flutter_client_sdk` (`launchdarkly_flutter_client_sdk`) — the published Flutter SDK. Wraps `LDCommonClient` and provides Flutter-specific `Persistence` (`shared_preferences`), env reporter (`package_info_plus`/`device_info_plus`), state detection (`connectivity_plus` + lifecycle), and a `ConnectionManager`.
+- `apps/sse_contract_test_service` and `apps/flutter_client_contract_test_service` — test service harnesses driven by LaunchDarkly's centralized contract test runners.
+- `architechture/` — Mermaid diagrams describing high-level architecture and the `identify` flow. Note the misspelling of the directory.
+
+Inter-package dependencies are pinned to exact versions in `pubspec.yaml` files. See `RELEASING.md`: a change to `common` requires a release-in-dependency-order (common → common_client → flutter_client_sdk), with a manual PR between each release to bump the pinned version.
+
+## Common commands
+
+All commands are run from the repo root and go through Melos.
+
+```
+dart pub global activate melos          # one-time
+melos bootstrap                          # install deps for every package
+melos run analyze                        # dart analyze --fatal-infos across all packages
+melos run fix                            # dart fix --apply
+melos run test                           # runs `flutter test --coverage` in common, common_client, flutter_client_sdk
+melos run sse-contract-tests             # start SSE contract service and run the v2 harness
+melos run client-contract-tests          # start Flutter client contract service and run the SDK harness
+melos run coverage-report                # merge lcov files and show coverage value (requires `dart pub global activate coverde`)
+melos run coverage-report-html           # same, but emits HTML to coverage/html/
+melos run launchdarkly_flutter_example   # build/run the example app for manual testing
+```
+
+To run a single test file, cd into the package and use Flutter directly, e.g. `cd packages/common_client && flutter test test/path/to/file_test.dart`. The `melos run test` target only covers `launchdarkly_dart_common`, `launchdarkly_common_client`, and `launchdarkly_flutter_client_sdk` — `event_source_client` tests are not yet wired in.
+
+## Architecture
+
+The Flutter SDK is a thin adapter layer around `LDCommonClient` (in `common_client`). `LDClient` in `packages/flutter_client_sdk/lib/src/ld_client.dart` constructs a `CommonPlatform` with platform-specific implementations and delegates flag evaluation, identify, events, and data source management to the common client.
+
+Key collaborators inside `LDCommonClient`:
+
+- **FlagManager** owns `FlagStore` (in-memory flag cache), `FlagUpdater` (emits `FlagsChangedEvent`s), and `FlagPersistence` (writes through to a `Persistence` implementation).
+- **DataSourceManager** selects between `StreamingDataSource` (SSE, via `event_source_client`) and `PollingDataSource` based on `ConnectionMode`, and routes updates through `DataSourceEventHandler` into the `FlagManager`.
+- **Context modifiers** (anonymous key generation, auto-env attributes) mutate the inbound `LDContext` before evaluation.
+- **Hooks** and **plugins** wrap variation/identify/track calls; plugins can also contribute hooks (see `safeGetHooks` + `combineHooks` used by `LDClient`).
+
+Flutter-specific additions layered on top:
+
+- `SharedPreferencesPersistence` implements the `Persistence` interface.
+- `PlatformEnvReporter` implements `EnvironmentReporter` using `package_info_plus` / `device_info_plus`.
+- `FlutterStateDetector` combines `connectivity_plus` with app lifecycle events to feed the `ConnectionManager`, which switches `ConnectionMode` (streaming / polling / offline) based on foreground/background and network state.
+
+See `architechture/high_level.md` for the class diagram and `architechture/identify.md` for the identify sequence.
+
+## Conventions
+
+- Follow `common_analysis.yaml`: relative imports inside a package's `lib/`, single quotes, explicit return types, and close your `StreamSink`s.
+- Code changes use Conventional Commits (`feat:`, `fix:`, `chore:`, …). Release PRs are produced by release-please and the flow is described in `RELEASING.md`. The SDK version string in `packages/flutter_client_sdk/lib/src/ld_client.dart` carries a `// x-release-please-version` marker — do not edit it manually.
+- Public API from `common` and `common_client` is re-exported through `packages/common_client/lib/launchdarkly_common_client.dart`; when adding new public types, add them to that export list so the Flutter package can surface them.

--- a/apps/flutter_client_contract_test_service/pubspec.lock
+++ b/apps/flutter_client_contract_test_service/pubspec.lock
@@ -393,14 +393,14 @@ packages:
       path: "../../packages/common_client"
       relative: true
     source: path
-    version: "1.7.0"
+    version: "1.9.0"
   launchdarkly_dart_common:
     dependency: "direct overridden"
     description:
       path: "../../packages/common"
       relative: true
     source: path
-    version: "1.6.1"
+    version: "1.8.0"
   launchdarkly_event_source_client:
     dependency: "direct overridden"
     description:
@@ -414,7 +414,7 @@ packages:
       path: "../../packages/flutter_client_sdk"
       relative: true
     source: path
-    version: "4.13.0"
+    version: "4.15.0"
   lints:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
Adds CLAUDE.md with repo-level architecture and Melos command notes, and a project-level .claude/ directory containing a Stop hook that runs `melos run analyze` and `melos run test` before allowing a session to end. The hook logic lives in
.claude/hooks/stop-lint-test.sh to keep settings.json readable.

Also refreshes apps/flutter_client_contract_test_service/pubspec.lock from `melos bootstrap`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds developer tooling/docs and a Claude stop-hook script; only functional change is local workflow enforcement plus a lockfile refresh.
> 
> **Overview**
> Adds Claude Code configuration under `.claude/`, including a **Stop hook** that runs `melos run analyze` and `melos run test` (with a 15-minute timeout) and blocks ending a session on failures.
> 
> Introduces `CLAUDE.md` with repository layout, Melos command references, and contribution conventions for working in this monorepo.
> 
> Refreshes `apps/flutter_client_contract_test_service/pubspec.lock` from `melos bootstrap`, updating pinned path package versions (e.g., `launchdarkly_common_client`, `launchdarkly_dart_common`, `launchdarkly_flutter_client_sdk`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c82a852f7089a215a2f1deeb7166f73e61573d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->