### PR TITLE
chore: Update contract-tests action to v1.3.0 and pass token to SSE step

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -68,19 +68,27 @@ runs:
       run: |
         pushd apps/flutter_client_contract_test_service
         flutter test bin/contract_test_service.dart > test-service.log 2>&1 & disown
-    - uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1.0.1
+    - uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1.3.0
       with:
         test_service_port: 8080
         token: ${{ inputs.github_token }}
+        enable_persistence_tests: false
         extra_params: '-status-timeout 100 --skip-from=./apps/flutter_client_contract_test_service/testharness-suppressions.txt'
 
-    - name: SSE Contract Tests
+    - name: SSE Contract Tests Service
       shell: bash
       run: |
         pushd apps/sse_contract_test_service
         dart run bin/sse_contract_test_service.dart > test-service.log 2>&1 & disown
-        curl -s https://raw.githubusercontent.com/launchdarkly/sse-contract-tests/v2.0.0/downloader/run.sh | VERSION=v2 PARAMS="-url http://localhost:8080 -debug -stop-service-at-end" sh
-        popd
+    - uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1.3.0
+      with:
+        repo: 'sse-contract-tests'
+        branch: 'v2.0.0'
+        version: 'v2'
+        test_service_port: 8080
+        debug_logging: true
+        enable_persistence_tests: false
+        token: ${{ inputs.github_token }}
 
     - name: Upload Test Service Logs
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02


### PR DESCRIPTION
## Summary

- Bumps `launchdarkly/gh-actions/actions/contract-tests` from `contract-tests-v1.0.1` to `contract-tests-v1.3.0` for the SDK contract tests step.
- Replaces the inline `curl ... | sh` SSE downloader invocation with the same `contract-tests@contract-tests-v1.3.0` action (`repo: sse-contract-tests`, `branch: v2.0.0`, `version: v2`, `debug_logging: true`, `enable_persistence_tests: false`) so the existing harness version is preserved.
- Passes `token: ${{ inputs.github_token }}` to the SSE step so the downloader script and harness fetch are no longer subject to anonymous GitHub API rate limits.
- Adds `enable_persistence_tests: false` to the SDK contract tests step to preserve the previous behavior, since v1.2.0+ flips the default to `true`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate CI risk: updates external GitHub Action versions and changes how SSE contract tests are invoked, which could alter test execution or fail due to action/harness behavior changes.
> 
> **Overview**
> Updates the shared CI composite to run contract tests via `launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1.3.0` (from `v1.0.1`) and explicitly disables persistence tests to preserve prior behavior.
> 
> Replaces the inline SSE harness `curl | sh` invocation with the same `contract-tests` action (pinning `sse-contract-tests` `v2.0.0`/`v2`) and passes `token: ${{ inputs.github_token }}` to avoid anonymous GitHub API rate limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f83277b5d834b25181a3f3a34543e9d3ed5980c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->