### PR TITLE
feat: add SSECapability surface to SSEClient

### DIFF
--- a/packages/common_client/test/data_sources/streaming_data_source_test.dart
+++ b/packages/common_client/test/data_sources/streaming_data_source_test.dart
@@ -30,6 +30,9 @@ class MockSseClient implements SSEClient {
 
   @override
   Stream<MessageEvent> get stream => mockStream;
+
+  @override
+  bool hasCapability(SSECapability capability) => true;
 }
 
 (

--- a/packages/event_source_client/lib/launchdarkly_event_source_client.dart
+++ b/packages/event_source_client/lib/launchdarkly_event_source_client.dart
@@ -17,6 +17,17 @@ export 'src/test_sse_client.dart' show TestSseClient;
 export 'src/logging.dart'
     show EventSourceLogger, LogLevel, NoOpLogger, PrintLogger;
 
+/// Optional behaviors that an [SSEClient] implementation may or may not
+/// support. Callers query support with [SSEClient.hasCapability] and
+/// route around missing capabilities (for example, by switching to a
+/// query-parameter form of authentication when the transport cannot
+/// send custom request headers).
+enum SSECapability {
+  /// The transport can send custom request headers. False for the
+  /// browser native `EventSource` API; true for HTTP-based clients.
+  requestHeaders,
+}
+
 /// HTTP methods supported by the event source client.
 enum SseHttpMethod {
   get('GET'),
@@ -63,6 +74,13 @@ abstract class SSEClient {
   /// establishes a new connection respecting delay/backoff as if this was
   /// an error condition with the connection.
   void restart();
+
+  /// Whether this implementation supports the given [capability]. Lets
+  /// callers detect transport limitations at runtime — for example, the
+  /// browser native `EventSource` does not support
+  /// [SSECapability.requestHeaders], so callers that need to authenticate
+  /// must fall back to a URL-based scheme.
+  bool hasCapability(SSECapability capability);
 
   /// Factory constructor to return the platform implementation.
   ///
@@ -121,6 +139,7 @@ abstract class SSEClient {
     String? body,
     SseHttpMethod httpMethod = SseHttpMethod.get,
     Stream<Event>? sourceStream,
+    Set<SSECapability>? capabilities,
   }) {
     return TestSseClient.internal(
         headers: UnmodifiableMapView(headers),
@@ -128,6 +147,7 @@ abstract class SSEClient {
         readTimeout: readTimeout,
         body: body,
         httpMethod: httpMethod,
-        sourceStream: sourceStream);
+        sourceStream: sourceStream,
+        capabilities: capabilities);
   }
 }

--- a/packages/event_source_client/lib/launchdarkly_event_source_client.dart
+++ b/packages/event_source_client/lib/launchdarkly_event_source_client.dart
@@ -22,10 +22,25 @@ export 'src/logging.dart'
 /// route around missing capabilities (for example, by switching to a
 /// query-parameter form of authentication when the transport cannot
 /// send custom request headers).
-enum SSECapability {
+///
+/// Modeled as a class with private-constructor static-const instances
+/// rather than an enum so adding a new capability is source-compatible
+/// for users -- a `switch (capability)` over an enum becomes
+/// non-exhaustive when a new value is added.
+class SSECapability {
+  /// The capability identifier. Stable across releases and intended
+  /// only for diagnostics; comparisons should use the static const
+  /// members directly (e.g. `cap == SSECapability.requestHeaders`).
+  final String value;
+
+  const SSECapability._(this.value);
+
   /// The transport can send custom request headers. False for the
   /// browser native `EventSource` API; true for HTTP-based clients.
-  requestHeaders,
+  static const SSECapability requestHeaders = SSECapability._('requestHeaders');
+
+  @override
+  String toString() => 'SSECapability.$value';
 }
 
 /// HTTP methods supported by the event source client.
@@ -82,7 +97,7 @@ abstract class SSEClient {
   /// must fall back to a URL-based scheme.
   ///
   /// The default implementation returns `false` for every capability so
-  /// adding new capabilities to the enum (or adding this method to an
+  /// adding a new capability constant (or adding this method to an
   /// existing external implementation) is source-compatible. Concrete
   /// implementations should override and report what they actually
   /// support.

--- a/packages/event_source_client/lib/launchdarkly_event_source_client.dart
+++ b/packages/event_source_client/lib/launchdarkly_event_source_client.dart
@@ -80,7 +80,13 @@ abstract class SSEClient {
   /// browser native `EventSource` does not support
   /// [SSECapability.requestHeaders], so callers that need to authenticate
   /// must fall back to a URL-based scheme.
-  bool hasCapability(SSECapability capability);
+  ///
+  /// The default implementation returns `false` for every capability so
+  /// adding new capabilities to the enum (or adding this method to an
+  /// existing external implementation) is source-compatible. Concrete
+  /// implementations should override and report what they actually
+  /// support.
+  bool hasCapability(SSECapability capability) => false;
 
   /// Factory constructor to return the platform implementation.
   ///

--- a/packages/event_source_client/lib/src/sse_client_html.dart
+++ b/packages/event_source_client/lib/src/sse_client_html.dart
@@ -112,6 +112,14 @@ class HtmlSseClient implements SSEClient {
       _setupConnection();
     });
   }
+
+  @override
+  bool hasCapability(SSECapability capability) {
+    // The browser native `EventSource` cannot send custom request
+    // headers, only supports `GET`, and silently discards a request
+    // body. None of the FDv2-relevant capabilities are supported here.
+    return false;
+  }
 }
 
 SSEClient getSSEClient(

--- a/packages/event_source_client/lib/src/sse_client_http.dart
+++ b/packages/event_source_client/lib/src/sse_client_http.dart
@@ -111,6 +111,13 @@ class HttpSseClient implements SSEClient {
       _resetRequest.sink.add(null);
     }
   }
+
+  @override
+  bool hasCapability(SSECapability capability) {
+    return switch (capability) {
+      SSECapability.requestHeaders => true,
+    };
+  }
 }
 
 /// No op sink.  Exists to accommodate unit testing.

--- a/packages/event_source_client/lib/src/sse_client_http.dart
+++ b/packages/event_source_client/lib/src/sse_client_http.dart
@@ -113,11 +113,8 @@ class HttpSseClient implements SSEClient {
   }
 
   @override
-  bool hasCapability(SSECapability capability) {
-    return switch (capability) {
-      SSECapability.requestHeaders => true,
-    };
-  }
+  bool hasCapability(SSECapability capability) =>
+      capability == SSECapability.requestHeaders;
 }
 
 /// No op sink.  Exists to accommodate unit testing.

--- a/packages/event_source_client/lib/src/test_sse_client.dart
+++ b/packages/event_source_client/lib/src/test_sse_client.dart
@@ -15,6 +15,7 @@ final class TestSseClient implements SSEClient {
   final Duration readTimeout;
   final String? body;
   final SseHttpMethod httpMethod;
+  final Set<SSECapability> _capabilities;
   late final Stream<Event>? _sourceStream;
   StreamSubscription<Event>? _sourceStreamSubscription;
 
@@ -31,6 +32,10 @@ final class TestSseClient implements SSEClient {
 
   @override
   Stream<Event> get stream => _messageEventsController.stream;
+
+  @override
+  bool hasCapability(SSECapability capability) =>
+      _capabilities.contains(capability);
 
   /// Emit an event on the stream.
   /// Has no effect if the client has been closed.
@@ -66,7 +71,8 @@ final class TestSseClient implements SSEClient {
     required this.body,
     required this.httpMethod,
     Stream<Event>? sourceStream,
-  }) {
+    Set<SSECapability>? capabilities,
+  }) : _capabilities = capabilities ?? {SSECapability.requestHeaders} {
     _sourceStream = sourceStream;
     _messageEventsController = StreamController<Event>.broadcast(
       onListen: () {

--- a/packages/event_source_client/test/sse_capability_test.dart
+++ b/packages/event_source_client/test/sse_capability_test.dart
@@ -1,0 +1,57 @@
+// ignore_for_file: close_sinks
+
+import 'package:launchdarkly_event_source_client/launchdarkly_event_source_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('default HTTP SSE client', () {
+    test('reports SSECapability.requestHeaders as supported', () {
+      final client = SSEClient(Uri.parse('https://example.test'), {'put'});
+      try {
+        expect(client.hasCapability(SSECapability.requestHeaders), isTrue);
+      } finally {
+        client.close();
+      }
+    });
+  });
+
+  group('TestSseClient', () {
+    test(
+        'defaults to supporting SSECapability.requestHeaders so existing '
+        'streaming tests behave like the production HTTP client', () {
+      final client = SSEClient.testClient(Uri.parse('/x'), {'put'});
+      try {
+        expect(client.hasCapability(SSECapability.requestHeaders), isTrue);
+      } finally {
+        client.close();
+      }
+    });
+
+    test('honors an empty capability set to simulate the browser EventSource',
+        () {
+      final client = SSEClient.testClient(
+        Uri.parse('/x'),
+        {'put'},
+        capabilities: const {},
+      );
+      try {
+        expect(client.hasCapability(SSECapability.requestHeaders), isFalse);
+      } finally {
+        client.close();
+      }
+    });
+
+    test('honors an explicit capability set', () {
+      final client = SSEClient.testClient(
+        Uri.parse('/x'),
+        {'put'},
+        capabilities: const {SSECapability.requestHeaders},
+      );
+      try {
+        expect(client.hasCapability(SSECapability.requestHeaders), isTrue);
+      } finally {
+        client.close();
+      }
+    });
+  });
+}


### PR DESCRIPTION
Adds the capability-discovery wire that the FDv2 streaming source (SDK-2185) needs to decide where to put the credential. Currently the html SSE client silently drops the `headers` argument because the browser native `EventSource` API doesn't support custom headers, but there's no way for callers to detect that. This PR adds one.

## Changes

- **New enum** `SSECapability` with one initial value, `requestHeaders`. The enum is the natural place to add future capabilities (custom HTTP methods, request body, etc.) without an API break.
- **New abstract method** `bool hasCapability(SSECapability)` on `SSEClient`.
- **Per-variant implementations:**
  - `HttpSseClient` returns `true` for `requestHeaders`.
  - `HtmlSseClient` returns `false` for everything (the browser native `EventSource` silently drops headers, only supports `GET`, and ignores a request body — none of the FDv2-relevant capabilities apply).
  - `TestSseClient` accepts an optional `Set<SSECapability>` constructor parameter so tests can simulate either transport. Defaults to the HTTP set so existing streaming tests behave unchanged.
- **`MockSseClient`** in `streaming_data_source_test.dart` adds the new method (returns `true`, matching FDv1's HTTP transport).

## Why this is its own PR

It's repository-wide infrastructure that's FDv1-neutral (the FDv1 streaming source doesn't call `hasCapability`), so it can land independently of any FDv2 work. SDK-2185 will use it to route auth into a URL query parameter when the transport returns `false` for `requestHeaders`.

## Verification

- `dart analyze lib test` clean in `event_source_client/`.
- New `sse_capability_test.dart` covers the http variant, the test variant default, an empty capability set, and an explicit set.
- `melos run analyze` + `melos run test` both pass workspace-wide.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public `SSEClient` interface and behavior for downstream implementers; capability reporting is new but should be low-impact if consumers don’t rely on it yet.
> 
> **Overview**
> Adds a new `SSECapability` surface and `SSEClient.hasCapability()` API so callers can detect transport limitations at runtime (initial capability: `requestHeaders`).
> 
> Implements capability reporting across transports (`HttpSseClient` supports request headers; `HtmlSseClient` reports none), extends `TestSseClient`/`SSEClient.testClient()` to accept an optional capability set (defaulting to header support), updates streaming tests’ mock client to satisfy the new interface, and adds unit tests validating capability behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af5b20f2034b4f96398958b79f6a7643f92244ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->