### PR TITLE
ci: bump lower CI matrix to Flutter 3.22.3 / Dart 3.4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         versions:
-          - { flutter: '3.22.0', dart: '3.4.0' }
+          - { flutter: '3.22.3', dart: '3.4.4' }
           - { flutter: '3.29.3', dart: '3.7.2' }
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The `build-test (3.22.0, 3.4.0)` matrix row hits a flaky crash inside the Dart `pub` tool during `flutter pub get`:

\`\`\`
Null check operator used on a null value
package:pub/src/source/hosted.dart 760:33
  HostedSource._getAdvisories.readAdvisoriesFromCache
package:pub/src/source/hosted.dart 778:12
  HostedSource._getAdvisories
\`\`\`

The crash depends on the state of the pub advisories cache at the moment of resolution, so it presents as a flake — sometimes the run passes, sometimes it fails before our test code executes. Confirmed not in our code (failure is during dependency resolution).

The bug is tracked at [dart-lang/pub#4312](https://github.com/dart-lang/pub/issues/4312) and was fixed in [Dart SDK 3.4.4](https://github.com/dart-lang/sdk/blob/stable/CHANGELOG.md#344---2024-06-12) (June 2024). Flutter 3.22.3 (July 2024) is the first stable Flutter release that bundles Dart 3.4.4.

Bumping the lower row from `(3.22.0, 3.4.0)` to `(3.22.3, 3.4.4)` is the minimal change that keeps backward-compat coverage intact while skipping the broken pub binary. The newer row `(3.29.3, 3.7.2)` was already passing.

## Test plan

- [ ] `build-test (3.22.3, 3.4.4)` and `build-test (3.29.3, 3.7.2)` both pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just updates the CI test matrix tool versions. Main impact is slightly shifting the minimum supported Flutter/Dart versions exercised in CI.
> 
> **Overview**
> Updates GitHub Actions CI `build-test` matrix to run the lower-version job on **Flutter 3.22.3 / Dart 3.4.4** instead of **3.22.0 / 3.4.0**, keeping the newer matrix row unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf3f792685fc6e70d98981d427d1f3a60e79975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->