### PR TITLE
ci: grant pull-requests:read on lint-pr-title caller

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint-pr-title:
     uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main


### PR DESCRIPTION
The reusable workflow at \`launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main\` requests \`pull-requests: read\`. The caller workflow in this repo (\`.github/workflows/lint-pr-title.yml\`) has no \`permissions:\` block, so it inherits the default scope which on this repo is \`pull-requests: none\`. GitHub rejects every run of the caller with:

> Invalid workflow file: .github/workflows/lint-pr-title.yml#L11
> Error calling workflow 'launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main'.
> The nested job 'main' is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.

The fix is a three-line addition declaring the minimum scope the reusable workflow needs:

\`\`\`yaml
permissions:
  pull-requests: read
\`\`\`

## Test plan

- [ ] Workflow no longer reports a startup_failure on PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only narrows/sets GitHub Actions permissions for a single workflow and doesn’t affect application runtime behavior.
> 
> **Overview**
> Fixes the `Lint PR title` GitHub Actions workflow failing to start by explicitly granting **minimum required permissions** (`permissions: pull-requests: read`) to the caller workflow when invoking the reusable `launchdarkly/gh-actions` lint workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 314693cf99357b83a9c008b163bc955ee1a7ef19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->