### PR TITLE
feat: add isClosed observer to TestSseClient

### DIFF
--- a/packages/event_source_client/lib/src/test_sse_client.dart
+++ b/packages/event_source_client/lib/src/test_sse_client.dart
@@ -37,6 +37,12 @@ final class TestSseClient implements SSEClient {
   bool hasCapability(SSECapability capability) =>
       _capabilities.contains(capability);
 
+  /// Whether [close] has been called on this client. Test-only --
+  /// production [SSEClient] implementations do not expose this state,
+  /// and tests asserting against it are inherently white-box. Use to
+  /// verify that code under test correctly tears the connection down.
+  bool get isClosed => _messageEventsController.isClosed;
+
   /// Emit an event on the stream.
   /// Has no effect if the client has been closed.
   ///


### PR DESCRIPTION
Adds a one-line, additive `bool get isClosed` to `TestSseClient` so test code can assert that the system under test correctly calls `close()` on its SSE client.

\`\`\`dart
/// Whether [close] has been called on this client. Test-only --
/// production [SSEClient] implementations do not expose this state,
/// and tests asserting against it are inherently white-box. Use to
/// verify that code under test correctly tears the connection down.
bool get isClosed => _messageEventsController.isClosed;
\`\`\`

## Why this is its own PR

Cleaner changelog: this is a `feat:` for the `launchdarkly_event_source_client` package; the FDv2 streaming work that consumes it (PR #267) is `feat:` for `launchdarkly_common_client`. Splitting them lets release-please attribute each correctly.

## Why test-only is OK on a public API

The `TestSseClient` class is already documented as test-only:

> An SSE client to use for testing.
>
> Changes may be made to this class without following semantic conventions.

The new getter inherits that contract; the docstring on `isClosed` reiterates it explicitly so a reader of the getter alone has the context.

## Verification

`dart format`, `dart analyze lib test`, and the full event_source_client test suite (46 tests) all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change limited to the test-only `TestSseClient` API. No production SSE transport logic or data handling is modified.
> 
> **Overview**
> Adds a test-only `isClosed` getter to `TestSseClient` so unit tests can assert that code under test properly calls `close()` and tears down the SSE stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3475ea5f0709e8672ea7ad317ac92a55dcc4b37a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->