### PR TITLE
fix: Reject "multi" as the kind of an individual context

### DIFF
--- a/packages/common/lib/src/ld_context.dart
+++ b/packages/common/lib/src/ld_context.dart
@@ -20,7 +20,7 @@ String _encodeKey(String key) {
 }
 
 bool _validKind(String kind) {
-  return kind != 'kind' && _kindExp.hasMatch(kind);
+  return kind != 'kind' && kind != 'multi' && _kindExp.hasMatch(kind);
 }
 
 bool _referenceIs(AttributeReference reference, String value) {

--- a/packages/common/test/ld_context_test.dart
+++ b/packages/common/test/ld_context_test.dart
@@ -52,11 +52,22 @@ void main() {
   });
 
   group('given invalid kinds', () {
-    for (var kind in ['', 'kind', '#*%']) {
-      test('invalid kinds produce invalid contexts', () {
+    for (var kind in ['', 'kind', 'multi', '#*%']) {
+      test('kind "$kind" produces an invalid context', () {
         expect(LDContextBuilder().kind(kind, 'my-key').build().valid, false);
       });
     }
+
+    test('a multi-context containing an individual "multi" kind is invalid',
+        () {
+      final context = LDContextBuilder()
+          .kind('user', 'user-key')
+          .kind('multi', 'other-key')
+          .build();
+      expect(context.valid, false);
+      expect(context.canonicalKey, '');
+      expect(context.keys, isEmpty);
+    });
   });
 
   test('can get the canonical key for an invalid context', () {


### PR DESCRIPTION
Refs SDK-2383.

## Summary

The string `"multi"` is reserved as the LaunchDarkly multi-context discriminator. An individual context must not use `"multi"` as its kind. The internal `_validKind` helper in `packages/common/lib/src/ld_context.dart` was only rejecting `"kind"`; building with `.kind("multi", ...)` was producing a *valid* `LDContext`, and a multi-context that included `"multi"` as one of its sub-kinds was also valid.

```dart
bool _validKind(String kind) {
-  return kind != 'kind' && _kindExp.hasMatch(kind);
+  return kind != 'kind' && kind != 'multi' && _kindExp.hasMatch(kind);
}
```

This propagates the kind validation Flutter SDK already implements for `"kind"` to also cover `"multi"`. Both single-kind and multi-context build paths run every sub-kind through `_validKind`, so a single change covers both.

## Test plan

- [x] `flutter test test/ld_context_test.dart` — 36 tests pass (new + existing)
- [x] `flutter test` (full common package) — 437 tests pass
- [x] `dart analyze --fatal-infos lib test` — no issues
- [x] `dart format` — no changes
- [x] Manual: `LDContextBuilder().kind('multi', 'alice').build().valid` is now `false`; previously `true`
- [x] Manual: a multi-context that includes a `"multi"` sub-kind builds as invalid

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small validation tightening that only changes behavior for previously-accepted invalid input (kind == "multi"). Main risk is backward incompatibility for callers incorrectly using "multi" as a kind, now producing invalid contexts.
> 
> **Overview**
> Reserves `"multi"` by updating kind validation so an individual context cannot use `kind == "multi"`, causing such contexts (and multi-contexts that include a `"multi"` sub-kind) to build as invalid.
> 
> Updates tests to treat `"multi"` as an invalid kind and adds coverage ensuring invalid contexts return empty `canonicalKey` and `keys`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2abb8fe0a45127d749e7403dfde2bc67c0f9e9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->