### PR TITLE
feat: safeGetPluginHooks helper in common_client

### DIFF
--- a/packages/common_client/lib/launchdarkly_common_client.dart
+++ b/packages/common_client/lib/launchdarkly_common_client.dart
@@ -96,6 +96,7 @@ export 'src/plugins/plugin.dart'
         PluginMetadata,
         PluginSdkMetadata;
 
-export 'src/plugins/operations.dart' show safeGetHooks, safeRegisterPlugins;
+export 'src/plugins/operations.dart'
+    show safeGetHooks, safeGetPluginHooks, safeGetPluginName, safeRegisterPlugins;
 
 export 'src/config/defaults/credential_type.dart' show CredentialType;

--- a/packages/common_client/lib/launchdarkly_common_client.dart
+++ b/packages/common_client/lib/launchdarkly_common_client.dart
@@ -97,6 +97,10 @@ export 'src/plugins/plugin.dart'
         PluginSdkMetadata;
 
 export 'src/plugins/operations.dart'
-    show safeGetHooks, safeGetPluginHooks, safeGetPluginName, safeRegisterPlugins;
+    show
+        safeGetHooks,
+        safeGetPluginHooks,
+        safeGetPluginName,
+        safeRegisterPlugins;
 
 export 'src/config/defaults/credential_type.dart' show CredentialType;

--- a/packages/common_client/lib/src/plugins/operations.dart
+++ b/packages/common_client/lib/src/plugins/operations.dart
@@ -15,20 +15,26 @@ String safeGetPluginName<TClient>(PluginBase<TClient> plugin, LDLogger logger) {
   }
 }
 
+/// Returns the hooks for a single [plugin], or `null` if reading
+/// [PluginBase.hooks] throws.
+List<Hook>? safeGetPluginHooks<TClient>(
+    PluginBase<TClient> plugin, LDLogger logger) {
+  try {
+    return plugin.hooks;
+  } catch (err) {
+    logger.warn(
+        'Exception thrown getting hooks for plugin ${safeGetPluginName(plugin, logger)}. Unable to get hooks for plugin.');
+    return null;
+  }
+}
+
 List<Hook>? safeGetHooks<TClient>(
     List<PluginBase<TClient>>? plugins, LDLogger logger) {
   if (plugins == null) return null;
 
   return plugins
-      .map<List<Hook>>((plugin) {
-        try {
-          return plugin.hooks;
-        } catch (err) {
-          logger.warn(
-              'Exception thrown getting hooks for plugin ${safeGetPluginName(plugin, logger)}. Unable to get hooks for plugin.');
-        }
-        return [];
-      })
+      .map<List<Hook>>(
+          (plugin) => safeGetPluginHooks(plugin, logger) ?? [])
       .expand<Hook>((hooks) => hooks)
       .toList();
 }

--- a/packages/common_client/lib/src/plugins/operations.dart
+++ b/packages/common_client/lib/src/plugins/operations.dart
@@ -33,8 +33,7 @@ List<Hook>? safeGetHooks<TClient>(
   if (plugins == null) return null;
 
   return plugins
-      .map<List<Hook>>(
-          (plugin) => safeGetPluginHooks(plugin, logger) ?? [])
+      .map<List<Hook>>((plugin) => safeGetPluginHooks(plugin, logger) ?? [])
       .expand<Hook>((hooks) => hooks)
       .toList();
 }


### PR DESCRIPTION
## Summary
- Add `safeGetPluginHooks` to handle a single plugin, returning `null` if reading `PluginBase.hooks` throws.
- Refactor `safeGetHooks` to reuse `safeGetPluginHooks`, removing duplicated try/catch + warning logic.
- Export `safeGetPluginHooks` and `safeGetPluginName` from the package barrel file.

Split out from `andrey/register-plugin` so the `common_client` changes can be reviewed independently.

## Test plan
- [ ] `dart analyze` passes for `common_client`
- [ ] Existing plugin operations tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor with equivalent aggregate behavior for `safeGetHooks`; only expands the public API with defensive helpers, no auth or data-path changes.
> 
> **Overview**
> Introduces **`safeGetPluginHooks`** in `common_client` so a single plugin’s hooks are read inside the same try/catch + warn path that used to live inline in **`safeGetHooks`**. **`safeGetHooks`** now maps each plugin through **`safeGetPluginHooks`** and still treats failures as no hooks (`?? []`).
> 
> The package barrel **`launchdarkly_common_client.dart`** now publicly exports **`safeGetPluginHooks`** and **`safeGetPluginName`** alongside the existing plugin helpers, so downstream code can reuse per-plugin hook collection without duplicating error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f537962f9f85bd106e229ab727f5d6f2f8101eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->