### PR TITLE
chore: Use generic updater for example/pubspec.yaml in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,7 +17,10 @@
       "include-component-in-tag": false,
       "extra-files": [
         "lib/src/ld_client.dart",
-        "example/pubspec.yaml"
+        {
+          "type": "generic",
+          "path": "example/pubspec.yaml"
+        }
       ]
     }
   },


### PR DESCRIPTION
## Summary

- Restores the intent of #117 after the release-please-action v3 → v5 upgrade in #262 silently changed the default updater behavior for `.yaml` files in `extra-files`.
- Spells out `{ "type": "generic", "path": "example/pubspec.yaml" }` so the generic, marker-based updater is used explicitly — independent of whatever release-please core decides to default to.

## Background

Under release-please-action **v3**, a bare-string `extra-files` entry like `"example/pubspec.yaml"` resolved to the **generic** line-based updater. That updater honors `# x-release-please-version` markers and does pure textual replacement, leaving comments and formatting alone. Every release from 4.1.0 through 4.16.0 produced a clean one-line bump to `example/pubspec.yaml`.

PR #262 upgraded release-please-action to **v5**, which ships a much newer release-please core. In that version, bare-string entries are dispatched by file extension — and `.yaml` now binds to the **YAML updater**, which parses + re-serializes the file. The result is what we see in PR #287: ~80 lines deleted (all comments, blank lines, and the `# x-release-please-version` marker itself), the dep pin no longer bumps because its marker got stripped, and the example app's `version:` got rewritten to the SDK version. This is the exact failure mode #117 originally fixed back in January 2024.

Making the updater type explicit is the minimal fix; once this lands, release-please will regenerate PR #287 (the 4.17.0 release PR) and produce a clean diff to `example/pubspec.yaml`.

## Test plan

- [x] Merge this PR to main
- [ ] Confirm release-please regenerates PR #287 and that `packages/flutter_client_sdk/example/pubspec.yaml` shows only the dep-line bump (`4.16.0` → `4.17.0`), with all comments and the `# x-release-please-version` marker preserved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single release-automation config change with no runtime or application code impact.
> 
> **Overview**
> **Release-please config** for `packages/flutter_client_sdk` now declares `example/pubspec.yaml` as an explicit **generic** extra-file instead of a bare path string.
> 
> After the release-please-action v5 upgrade, bare `.yaml` entries use the YAML parse/reserialize updater, which broke releases by stripping `# x-release-please-version` markers and comments and rewriting the example app version incorrectly. The generic updater keeps marker-based line replacement so only the pinned SDK dependency line (e.g. `launchdarkly_flutter_client_sdk: 4.16.0`) bumps on release, matching the behavior from before #262.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f7c5b66d0d069c55c3ea5853960892d39d9f3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->