### PR TITLE
fix: Update launchdarkly_common_client to version 1.12.0

### DIFF
--- a/packages/flutter_client_sdk/pubspec.yaml
+++ b/packages/flutter_client_sdk/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   package_info_plus: ">=4.2.0 <11.0.0"
   device_info_plus: ">=9.1.1 <14.0.0"
-  launchdarkly_common_client: 1.11.0
+  launchdarkly_common_client: 1.12.0
   shared_preferences: ^2.2.2
   connectivity_plus: ">=5.0.2 <8.0.0"
   web: ^1.1.1


### PR DESCRIPTION
1.11 and 1.12 are functionally the same, but a git issue resulted in a second release publish. This will just sync up the version.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single dependency version pin with no SDK code changes in this diff; behavior shifts only via the upgraded common client.
> 
> **Overview**
> Pins **`launchdarkly_common_client`** from **1.11.0** to **1.12.0** in `packages/flutter_client_sdk/pubspec.yaml`, so the Flutter SDK pulls in the latest common client (including **FDv2 connection-mode resolution** from that release) without other manifest changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa3ae6481c45672871a4c260ba648c1195d83240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->