### PR TITLE
feat: Debounce lifecycle, network, and setMode signals in flutter SDK

### DIFF
--- a/packages/flutter_client_sdk/lib/src/connection_manager.dart
+++ b/packages/flutter_client_sdk/lib/src/connection_manager.dart
@@ -101,12 +101,31 @@ final class ConnectionManagerConfig {
   /// retry logic.
   final bool disableAutomaticBackgroundHandling;
 
+  /// Window across which lifecycle, network, and user-mode-override signals
+  /// are debounced before automatic resolution runs. A value of
+  /// [Duration.zero] disables debouncing (signals apply synchronously).
+  /// Defaults to one second.
+  final Duration debounceWindow;
+
+  /// The application's lifecycle state at construction time. Used to seed
+  /// the manager's initial lifecycle assumption so the SDK doesn't default
+  /// to foreground when the host platform already knows the app launched
+  /// into the background. Callers that can query the platform synchronously
+  /// (e.g. via [SchedulerBinding.instance.lifecycleState]) should pass the
+  /// resolved value here; callers without that information should leave
+  /// the default.
+  ///
+  /// Defaults to [ApplicationState.foreground].
+  final ApplicationState initialApplicationState;
+
   ConnectionManagerConfig({
     this.initialConnectionMode = ConnectionMode.streaming,
     this.backgroundConnectionMode = const FDv2Offline(),
     this.runInBackground = true,
     this.disableAutomaticBackgroundHandling = false,
     this.disableAutomaticNetworkHandling = false,
+    this.debounceWindow = const Duration(seconds: 1),
+    this.initialApplicationState = ApplicationState.foreground,
   });
 }
 
@@ -127,6 +146,8 @@ final class ConnectionManager {
   final StateDetector _detector;
   final ConnectionDestination _destination;
   final List<ModeResolutionEntry> _resolutionTable;
+  late final StateDebounceManager _debouncer;
+  late final StreamSubscription<DebouncedState> _debounceSub;
 
   StreamSubscription<ApplicationState>? _applicationStateSub;
   StreamSubscription<NetworkState>? _networkStateSub;
@@ -140,6 +161,11 @@ final class ConnectionManager {
 
   bool _offline = false;
 
+  /// Whether the SDK has been explicitly placed in the offline state.
+  ///
+  /// Assigning this property synchronously drives the resolved mode to
+  /// offline (or back to automatic resolution when set to `false`). It
+  /// intentionally bypasses the debounce window.
   bool get offline => _offline;
 
   set offline(bool offline) {
@@ -157,29 +183,58 @@ final class ConnectionManager {
         _config = config,
         _destination = destination,
         _resolutionTable = resolutionTable ?? flutterDefaultResolutionTable(),
-        _applicationState = ApplicationState.foreground,
+        _applicationState = config.initialApplicationState,
+        // Network has no synchronous platform API; start optimistic. If
+        // the network is actually unavailable, the first detector emission
+        // will trigger a debounced reconcile that flips us to offline.
+        // The common case (network available) is the best performing default.
         _networkState = NetworkState.available,
         _detector = detector {
+    _debouncer = StateDebounceManager(
+      initialState: DebouncedState(
+        networkAvailable: true,
+        inForeground:
+            config.initialApplicationState == ApplicationState.foreground,
+        requestedMode: null,
+      ),
+      debounceWindow: config.debounceWindow,
+    );
+    _debounceSub = _debouncer.stream.listen(_onDebounceReconcile);
+
     if (!_config.disableAutomaticBackgroundHandling) {
       _applicationStateSub =
-          detector.applicationState.listen((applicationState) {
-        // TODO (SDK-2187): plumb in debouncer here
-
-        _applicationState = applicationState;
-        _handleState();
-      });
+          detector.applicationState.listen(_onApplicationStateChanged);
     }
 
     if (!_config.disableAutomaticNetworkHandling) {
-      _networkStateSub = detector.networkState.listen((networkState) {
-        // TODO (SDK-2187): plumb in debouncer here
-
-        _networkState = networkState;
-        _destination
-            .setNetworkAvailability(networkState == NetworkState.available);
-        _handleState();
-      });
+      _networkStateSub = detector.networkState.listen(_onNetworkStateChanged);
     }
+  }
+
+  void _onApplicationStateChanged(ApplicationState newState) {
+    // Flushing on transition to background must not be debounced
+    if (newState == ApplicationState.background &&
+        _applicationState == ApplicationState.foreground &&
+        !_offline) {
+      _destination.flush();
+    }
+    _applicationState = newState;
+    _debouncer.setInForeground(newState == ApplicationState.foreground);
+  }
+
+  void _onNetworkStateChanged(NetworkState newState) {
+    _networkState = newState;
+    // Network-availability propagation to the destination is not debounced.
+    // It informs the underlying client's analytics-sending state, separate
+    // from the mode-resolution decision that the debouncer governs.
+    _destination.setNetworkAvailability(newState == NetworkState.available);
+    _debouncer.setNetworkAvailable(newState == NetworkState.available);
+  }
+
+  void _onDebounceReconcile(DebouncedState _) {
+    // The debouncer's snapshot is intentionally ignored; this manager owns
+    // the canonical view of lifecycle, network, override, and offline state.
+    _handleState();
   }
 
   void _handleState() {
@@ -228,14 +283,18 @@ final class ConnectionManager {
   void dispose() {
     _applicationStateSub?.cancel();
     _networkStateSub?.cancel();
+    _debounceSub.cancel();
+    _debouncer.close();
     _detector.dispose();
   }
 
-  /// Set the desired connection mode for the SDK. Passing null clears the
-  /// override and resumes automatic mode resolution.
+  /// Set the desired connection mode for the SDK. Setting an override takes
+  /// effect synchronously so subsequent automatic transitions are suppressed
+  /// immediately; applying the resolved mode is debounced. Passing null
+  /// clears the override and resumes automatic mode resolution.
   void setMode(FDv2ConnectionMode? mode) {
     _modeOverride = mode;
-    _handleState();
+    _debouncer.setRequestedMode(mode);
   }
 }
 

--- a/packages/flutter_client_sdk/lib/src/flutter_state_detector.dart
+++ b/packages/flutter_client_sdk/lib/src/flutter_state_detector.dart
@@ -22,10 +22,22 @@ final class FlutterStateDetector implements StateDetector {
   @override
   Stream<NetworkState> get networkState => _networkStateController.stream;
 
+  /// The application lifecycle state read synchronously at construction
+  /// time. Suitable for seeding [ConnectionManagerConfig.initialApplicationState].
+  ///
+  /// [SchedulerBinding.instance.lifecycleState] returns a cached value
+  /// populated by the framework when the OS pushes lifecycle messages.
+  /// The read is synchronous and depends only on
+  /// [WidgetsFlutterBinding.ensureInitialized] having been called -- which
+  /// the SDK already requires for [FlutterStateDetector] to function.
+  final ApplicationState initialApplicationState;
+
   late final LDAppLifecycleListener _lifecycleListener;
   late final StreamSubscription<dynamic> _connectivitySubscription;
 
-  FlutterStateDetector() {
+  FlutterStateDetector()
+      : initialApplicationState =
+            _resolveLifecycleState(SchedulerBinding.instance.lifecycleState) {
     final initialState = SchedulerBinding.instance.lifecycleState;
     if (initialState != null) {
       _handleApplicationLifecycle(initialState);
@@ -40,6 +52,18 @@ final class FlutterStateDetector implements StateDetector {
     _connectivitySubscription =
         Connectivity().onConnectivityChanged.listen(_setConnectivity);
   }
+
+  static ApplicationState _resolveLifecycleState(AppLifecycleState? state) =>
+      switch (state) {
+        AppLifecycleState.resumed => ApplicationState.foreground,
+        AppLifecycleState.hidden ||
+        AppLifecycleState.paused =>
+          ApplicationState.background,
+        AppLifecycleState.detached ||
+        AppLifecycleState.inactive ||
+        null =>
+          ApplicationState.foreground,
+      };
 
   void _setConnectivity(dynamic connectivityResult) {
     // TODO: This is a temporary fix to handle the breaking change in

--- a/packages/flutter_client_sdk/lib/src/ld_client.dart
+++ b/packages/flutter_client_sdk/lib/src/ld_client.dart
@@ -77,6 +77,7 @@ interface class LDClient {
     _client = LDCommonClient(config, platformImplementation, context,
         DiagnosticSdkData(name: sdkName, version: sdkVersion),
         hooks: combined);
+    final stateDetector = FlutterStateDetector();
     _connectionManager = ConnectionManager(
         logger: _client.logger,
         config: ConnectionManagerConfig(
@@ -85,13 +86,16 @@ interface class LDClient {
             backgroundConnectionMode:
                 FlutterDefaultConfig.defaultBackgroundConnectionMode,
             disableAutomaticBackgroundHandling:
-                config.offline || !config.applicationEvents.backgrounding,
+                !config.applicationEvents.backgrounding,
             disableAutomaticNetworkHandling:
-                config.offline || !config.applicationEvents.networkAvailability,
+                !config.applicationEvents.networkAvailability,
             runInBackground:
-                FlutterDefaultConfig.connectionManagerConfig.runInBackground),
+                FlutterDefaultConfig.connectionManagerConfig.runInBackground,
+            initialApplicationState: !config.applicationEvents.backgrounding
+                ? ApplicationState.foreground
+                : stateDetector.initialApplicationState),
         destination: DartClientAdapter(_client),
-        detector: FlutterStateDetector());
+        detector: stateDetector);
 
     if (config.offline) {
       _connectionManager.offline = true;

--- a/packages/flutter_client_sdk/pubspec.yaml
+++ b/packages/flutter_client_sdk/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   package_info_plus: ">=4.2.0 <11.0.0"
   device_info_plus: ">=9.1.1 <14.0.0"
-  launchdarkly_common_client: 1.12.0
+  launchdarkly_common_client: 1.13.0
   shared_preferences: ^2.2.2
   connectivity_plus: ">=5.0.2 <8.0.0"
   web: ^1.1.1
@@ -24,6 +24,7 @@ dev_dependencies:
   test: ^1.24.3
   lints: ^3.0.0
   mocktail: ^1.0.1
+  fake_async: ^1.3.1
 
 # The following section is specific to Flutter.
 flutter:

--- a/packages/flutter_client_sdk/test/persistence/connection_manager_test.dart
+++ b/packages/flutter_client_sdk/test/persistence/connection_manager_test.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:launchdarkly_common_client/launchdarkly_common_client.dart';
 import 'package:launchdarkly_flutter_client_sdk/src/connection_manager.dart';
 import 'package:test/test.dart';
@@ -50,6 +51,12 @@ final class MockStateDetector implements StateDetector {
   }
 }
 
+/// Drains one extra microtask after a detector event has propagated, so
+/// the debouncer's stream delivery (one async hop past
+/// `_onApplicationStateChanged` / `_onNetworkStateChanged`) reaches
+/// `_handleState` before assertions run.
+Future<void> _pumpDebouncerHop() => Future<void>.microtask(() {});
+
 void main() {
   setUpAll(() {
     registerFallbackValue(LDLogRecord(
@@ -69,7 +76,8 @@ void main() {
     final destination = MockDestination();
     final logAdapter = MockLogAdapter();
     final logger = LDLogger(adapter: logAdapter);
-    final config = ConnectionManagerConfig(runInBackground: false);
+    final config = ConnectionManagerConfig(
+        runInBackground: false, debounceWindow: Duration.zero);
     final mockDetector = MockStateDetector();
 
     final connectionManager = ConnectionManager(
@@ -82,6 +90,7 @@ void main() {
 
     // Wait for the state to propagate.
     await mockDetector.applicationState.first;
+    await _pumpDebouncerHop();
 
     verify(() => destination
         .setMode(const ResolvedOffline(OfflineBackgroundDisabled())));
@@ -102,7 +111,9 @@ void main() {
         final logAdapter = MockLogAdapter();
         final logger = LDLogger(adapter: logAdapter);
         final config = ConnectionManagerConfig(
-            runInBackground: false, initialConnectionMode: initialMode);
+            runInBackground: false,
+            initialConnectionMode: initialMode,
+            debounceWindow: Duration.zero);
         final mockDetector = MockStateDetector();
 
         final connectionManager = ConnectionManager(
@@ -115,6 +126,7 @@ void main() {
 
         // Wait for the state to propagate.
         await mockDetector.applicationState.first;
+        await _pumpDebouncerHop();
 
         verify(() => destination
             .setMode(const ResolvedOffline(OfflineBackgroundDisabled())));
@@ -124,6 +136,7 @@ void main() {
 
         // Wait for the state to propagate.
         await mockDetector.applicationState.first;
+        await _pumpDebouncerHop();
 
         verify(() => destination.setMode(switch (initialMode) {
               ConnectionMode.streaming => const ResolvedStreaming(),
@@ -145,7 +158,8 @@ void main() {
     final destination = MockDestination();
     final logAdapter = MockLogAdapter();
     final logger = LDLogger(adapter: logAdapter);
-    final config = ConnectionManagerConfig(runInBackground: true);
+    final config = ConnectionManagerConfig(
+        runInBackground: true, debounceWindow: Duration.zero);
     final mockDetector = MockStateDetector();
 
     final connectionManager = ConnectionManager(
@@ -158,6 +172,7 @@ void main() {
 
     // Wait for the state to propagate.
     await mockDetector.applicationState.first;
+    await _pumpDebouncerHop();
 
     verify(() => destination.flush());
     verify(
@@ -177,6 +192,7 @@ void main() {
     final config = ConnectionManagerConfig(
       runInBackground: true,
       backgroundConnectionMode: const FDv2Background(),
+      debounceWindow: Duration.zero,
     );
     final mockDetector = MockStateDetector();
 
@@ -189,6 +205,7 @@ void main() {
     mockDetector.setApplicationState(ApplicationState.background);
 
     await mockDetector.applicationState.first;
+    await _pumpDebouncerHop();
 
     verify(() => destination.flush());
     verify(() => destination.setMode(const ResolvedBackground()));
@@ -206,6 +223,7 @@ void main() {
     final config = ConnectionManagerConfig(
       runInBackground: true,
       backgroundConnectionMode: const FDv2Streaming(),
+      debounceWindow: Duration.zero,
     );
     final mockDetector = MockStateDetector();
 
@@ -218,6 +236,7 @@ void main() {
     mockDetector.setApplicationState(ApplicationState.background);
 
     await mockDetector.applicationState.first;
+    await _pumpDebouncerHop();
 
     verify(() => destination.flush());
     verify(() => destination.setMode(const ResolvedStreaming()));
@@ -232,7 +251,8 @@ void main() {
     final destination = MockDestination();
     final logAdapter = MockLogAdapter();
     final logger = LDLogger(adapter: logAdapter);
-    final config = ConnectionManagerConfig(runInBackground: true);
+    final config = ConnectionManagerConfig(
+        runInBackground: true, debounceWindow: Duration.zero);
     final mockDetector = MockStateDetector();
 
     final connectionManager = ConnectionManager(
@@ -245,6 +265,7 @@ void main() {
 
     // Wait for the state to propagate.
     await mockDetector.networkState.first;
+    await _pumpDebouncerHop();
 
     verify(() => destination.setNetworkAvailability(false));
     verify(() => destination
@@ -260,7 +281,8 @@ void main() {
     final destination = MockDestination();
     final logAdapter = MockLogAdapter();
     final logger = LDLogger(adapter: logAdapter);
-    final config = ConnectionManagerConfig(runInBackground: true);
+    final config = ConnectionManagerConfig(
+        runInBackground: true, debounceWindow: Duration.zero);
     final mockDetector = MockStateDetector();
 
     final connectionManager = ConnectionManager(
@@ -273,6 +295,7 @@ void main() {
 
     // Wait for the state to propagate.
     await mockDetector.networkState.first;
+    await _pumpDebouncerHop();
 
     verify(() => destination.setNetworkAvailability(false));
     reset(destination);
@@ -281,6 +304,7 @@ void main() {
 
     // Wait for the state to propagate.
     await mockDetector.networkState.first;
+    await _pumpDebouncerHop();
 
     verify(() => destination.setNetworkAvailability(true));
     connectionManager.dispose();
@@ -299,6 +323,7 @@ void main() {
       final config = ConnectionManagerConfig(
         runInBackground: true,
         backgroundConnectionMode: const FDv2Background(),
+        debounceWindow: Duration.zero,
       );
       final mockDetector = MockStateDetector();
 
@@ -311,12 +336,14 @@ void main() {
 
       mockDetector.setApplicationState(ApplicationState.background);
       await mockDetector.applicationState.first;
+      await _pumpDebouncerHop();
 
       verify(() => destination.setMode(const ResolvedBackground()));
       reset(destination);
 
       mockDetector.setNetworkAvailable(false);
       await mockDetector.networkState.first;
+      await _pumpDebouncerHop();
 
       verify(() => destination.setNetworkAvailability(false));
       verify(() => destination
@@ -336,6 +363,7 @@ void main() {
       final config = ConnectionManagerConfig(
         initialConnectionMode: ConnectionMode.polling,
         runInBackground: true,
+        debounceWindow: Duration.zero,
       );
       final mockDetector = MockStateDetector();
 
@@ -348,6 +376,7 @@ void main() {
 
       mockDetector.setNetworkAvailable(false);
       await mockDetector.networkState.first;
+      await _pumpDebouncerHop();
 
       verify(() => destination
           .setMode(const ResolvedOffline(OfflineNetworkUnavailable())));
@@ -355,6 +384,7 @@ void main() {
 
       mockDetector.setNetworkAvailable(true);
       await mockDetector.networkState.first;
+      await _pumpDebouncerHop();
 
       verify(() => destination.setNetworkAvailability(true));
       verify(() => destination.setMode(const ResolvedPolling()));
@@ -373,6 +403,7 @@ void main() {
       final config = ConnectionManagerConfig(
         initialConnectionMode: ConnectionMode.polling,
         runInBackground: true,
+        debounceWindow: Duration.zero,
       );
       final mockDetector = MockStateDetector();
 
@@ -393,6 +424,7 @@ void main() {
 
       mockDetector.setNetworkAvailable(false);
       await mockDetector.networkState.first;
+      await _pumpDebouncerHop();
 
       verify(() => destination
           .setMode(const ResolvedOffline(OfflineNetworkUnavailable())));
@@ -400,6 +432,7 @@ void main() {
 
       mockDetector.setNetworkAvailable(true);
       await mockDetector.networkState.first;
+      await _pumpDebouncerHop();
 
       verify(() => destination.setMode(const ResolvedPolling()));
       connectionManager.dispose();
@@ -417,6 +450,7 @@ void main() {
       final config = ConnectionManagerConfig(
         initialConnectionMode: ConnectionMode.polling,
         runInBackground: true,
+        debounceWindow: Duration.zero,
       );
       final mockDetector = MockStateDetector();
 
@@ -430,6 +464,7 @@ void main() {
 
       mockDetector.setNetworkAvailable(false);
       await mockDetector.networkState.first;
+      await _pumpDebouncerHop();
 
       verify(() => destination.setMode(const ResolvedPolling()));
       connectionManager.dispose();
@@ -443,7 +478,7 @@ void main() {
     final destination = MockDestination();
     final logAdapter = MockLogAdapter();
     final logger = LDLogger(adapter: logAdapter);
-    final config = ConnectionManagerConfig();
+    final config = ConnectionManagerConfig(debounceWindow: Duration.zero);
     final mockDetector = MockStateDetector();
 
     final connectionManager = ConnectionManager(
@@ -459,16 +494,20 @@ void main() {
     verify(() => destination.setEventSendingEnabled(false, flush: false));
     reset(destination);
 
-    mockDetector.setApplicationState(ApplicationState.foreground);
-    mockDetector.setNetworkAvailable(true);
+    // Push genuine state changes (defaults are foreground+available); the
+    // SDK should remain offline because the offline flag overrides automatic
+    // resolution.
+    mockDetector.setApplicationState(ApplicationState.background);
+    mockDetector.setNetworkAvailable(false);
 
     // Wait for the state to propagate.
     await mockDetector.applicationState.first;
     await mockDetector.networkState.first;
+    await _pumpDebouncerHop();
 
     verify(
         () => destination.setMode(const ResolvedOffline(OfflineSetOffline())));
-    verify(() => destination.setNetworkAvailability(true));
+    verify(() => destination.setNetworkAvailability(false));
     verify(() => destination.setEventSendingEnabled(false, flush: false));
     connectionManager.dispose();
   });
@@ -482,7 +521,9 @@ void main() {
     final logAdapter = MockLogAdapter();
     final logger = LDLogger(adapter: logAdapter);
     final config = ConnectionManagerConfig(
-        runInBackground: false, disableAutomaticBackgroundHandling: true);
+        runInBackground: false,
+        disableAutomaticBackgroundHandling: true,
+        debounceWindow: Duration.zero);
     final mockDetector = MockStateDetector();
 
     final connectionManager = ConnectionManager(
@@ -491,10 +532,16 @@ void main() {
         destination: destination,
         detector: mockDetector);
 
+    // Drain the debouncer's initial reconcile microtask before asserting,
+    // so the verifyNever checks only apply to events pushed after startup.
+    await Future<void>.microtask(() {});
+    reset(destination);
+
     mockDetector.setApplicationState(ApplicationState.background);
 
     // Wait for the state to propagate.
     await mockDetector.applicationState.first;
+    await _pumpDebouncerHop();
 
     verifyNever(() => destination.setMode(any()));
     verifyNever(() =>
@@ -511,7 +558,9 @@ void main() {
     final logAdapter = MockLogAdapter();
     final logger = LDLogger(adapter: logAdapter);
     final config = ConnectionManagerConfig(
-        runInBackground: false, disableAutomaticNetworkHandling: true);
+        runInBackground: false,
+        disableAutomaticNetworkHandling: true,
+        debounceWindow: Duration.zero);
     final mockDetector = MockStateDetector();
 
     final connectionManager = ConnectionManager(
@@ -520,10 +569,15 @@ void main() {
         destination: destination,
         detector: mockDetector);
 
+    // Drain the debouncer's initial reconcile microtask before asserting.
+    await Future<void>.microtask(() {});
+    reset(destination);
+
     mockDetector.setNetworkAvailable(false);
 
     // Wait for the state to propagate.
     await mockDetector.networkState.first;
+    await _pumpDebouncerHop();
 
     verifyNever(() => destination.setNetworkAvailability(any()));
     verifyNever(() =>
@@ -539,7 +593,8 @@ void main() {
     final destination = MockDestination();
     final logAdapter = MockLogAdapter();
     final logger = LDLogger(adapter: logAdapter);
-    final config = ConnectionManagerConfig(runInBackground: true);
+    final config = ConnectionManagerConfig(
+        runInBackground: true, debounceWindow: Duration.zero);
     final mockDetector = MockStateDetector();
 
     final connectionManager = ConnectionManager(
@@ -550,16 +605,19 @@ void main() {
 
     mockDetector.setApplicationState(ApplicationState.background);
     await mockDetector.applicationState.first;
+    await _pumpDebouncerHop();
 
     verify(
         () => destination.setMode(const ResolvedOffline(OfflineSetOffline())));
     reset(destination);
 
     connectionManager.setMode(const FDv2Polling());
+    await _pumpDebouncerHop();
     verify(() => destination.setMode(const ResolvedPolling()));
     reset(destination);
 
     connectionManager.setMode(null);
+    await _pumpDebouncerHop();
     verify(
         () => destination.setMode(const ResolvedOffline(OfflineSetOffline())));
     connectionManager.dispose();
@@ -573,13 +631,16 @@ void main() {
       (const FDv2Offline(), const ResolvedOffline(OfflineSetOffline())),
     ]) {
       final (requestedMode, expectedResolved) = entry;
-      test('it respects setMode($requestedMode)', () {
+      test('it respects setMode($requestedMode)', () async {
         registerFallbackValue(ConnectionMode.streaming);
 
         final destination = MockDestination();
         final logAdapter = MockLogAdapter();
         final logger = LDLogger(adapter: logAdapter);
-        final config = ConnectionManagerConfig(runInBackground: false);
+        final config = ConnectionManagerConfig(
+          runInBackground: false,
+          debounceWindow: Duration.zero,
+        );
         final mockDetector = MockStateDetector();
 
         final connectionManager = ConnectionManager(
@@ -588,8 +649,13 @@ void main() {
             destination: destination,
             detector: mockDetector);
 
+        // Drain the buffered initial reconcile before exercising setMode.
+        await Future<void>.microtask(() {});
         reset(destination);
         connectionManager.setMode(requestedMode);
+        // The setter's event also delivers asynchronously through the
+        // stream, so let that drain before verifying.
+        await Future<void>.microtask(() {});
 
         verify(() => destination.setMode(expectedResolved));
         verifyNever(
@@ -597,5 +663,240 @@ void main() {
         connectionManager.dispose();
       });
     }
+  });
+
+  group('debounce window', () {
+    test('rapid network changes settle to one reconcile', () {
+      fakeAsync((async) {
+        registerFallbackValue(ConnectionMode.streaming);
+        registerFallbackValue(const FDv2Streaming());
+
+        final destination = MockDestination();
+        final logAdapter = MockLogAdapter();
+        final logger = LDLogger(adapter: logAdapter);
+        final config = ConnectionManagerConfig(
+          runInBackground: true,
+          debounceWindow: const Duration(seconds: 1),
+        );
+        final mockDetector = MockStateDetector();
+
+        final connectionManager = ConnectionManager(
+            logger: logger,
+            config: config,
+            destination: destination,
+            detector: mockDetector);
+
+        // Drain the debouncer's initial reconcile so the burst-debounce
+        // assertions only see events pushed after startup.
+        async.flushMicrotasks();
+        reset(destination);
+
+        mockDetector.setNetworkAvailable(false);
+        async.elapse(const Duration(milliseconds: 200));
+        mockDetector.setNetworkAvailable(true);
+        async.elapse(const Duration(milliseconds: 200));
+        mockDetector.setNetworkAvailable(false);
+        async.elapse(const Duration(milliseconds: 200));
+
+        verifyNever(() => destination.setMode(any()));
+
+        async.elapse(const Duration(seconds: 1));
+        verify(() => destination.setMode(any())).called(1);
+
+        connectionManager.dispose();
+      });
+    });
+
+    test('background transition flushes immediately, not debounced', () {
+      fakeAsync((async) {
+        registerFallbackValue(ConnectionMode.streaming);
+
+        final destination = MockDestination();
+        final logAdapter = MockLogAdapter();
+        final logger = LDLogger(adapter: logAdapter);
+        final config = ConnectionManagerConfig(
+          runInBackground: false,
+          debounceWindow: const Duration(seconds: 1),
+        );
+        final mockDetector = MockStateDetector();
+
+        final connectionManager = ConnectionManager(
+            logger: logger,
+            config: config,
+            destination: destination,
+            detector: mockDetector);
+
+        mockDetector.setApplicationState(ApplicationState.background);
+        async.flushMicrotasks();
+        // Flush is synchronous on foreground->background transition.
+        verify(() => destination.flush()).called(1);
+
+        connectionManager.dispose();
+      });
+    });
+
+    test('setMode debounces the resolved-mode application', () {
+      fakeAsync((async) {
+        registerFallbackValue(ConnectionMode.streaming);
+
+        final destination = MockDestination();
+        final logAdapter = MockLogAdapter();
+        final logger = LDLogger(adapter: logAdapter);
+        final config = ConnectionManagerConfig(
+          runInBackground: true,
+          debounceWindow: const Duration(seconds: 1),
+        );
+        final mockDetector = MockStateDetector();
+
+        final connectionManager = ConnectionManager(
+            logger: logger,
+            config: config,
+            destination: destination,
+            detector: mockDetector);
+
+        // Drain the debouncer's initial reconcile microtask.
+        async.flushMicrotasks();
+        reset(destination);
+
+        connectionManager.setMode(const FDv2Polling());
+        verifyNever(() => destination.setMode(any()));
+
+        async.elapse(const Duration(seconds: 1));
+        verify(() => destination.setMode(const ResolvedPolling())).called(1);
+
+        connectionManager.dispose();
+      });
+    });
+
+    test(
+        'setMode override wins over a network event arriving mid-debounce-window',
+        () {
+      fakeAsync((async) {
+        registerFallbackValue(ConnectionMode.streaming);
+
+        final destination = MockDestination();
+        final logAdapter = MockLogAdapter();
+        final logger = LDLogger(adapter: logAdapter);
+        final config = ConnectionManagerConfig(
+          runInBackground: true,
+          debounceWindow: const Duration(seconds: 1),
+        );
+        final mockDetector = MockStateDetector();
+
+        final connectionManager = ConnectionManager(
+            logger: logger,
+            config: config,
+            destination: destination,
+            detector: mockDetector);
+
+        // Drain the debouncer's initial reconcile microtask before the
+        // override-vs-network race begins.
+        async.flushMicrotasks();
+        reset(destination);
+
+        // t=0: user sets override.
+        connectionManager.setMode(const FDv2Streaming());
+
+        // t=500ms: network drops mid-window.
+        async.elapse(const Duration(milliseconds: 500));
+        mockDetector.setNetworkAvailable(false);
+        async.flushMicrotasks();
+
+        // Network availability propagates to the destination synchronously
+        // (not debounced) so the underlying client knows.
+        verify(() => destination.setNetworkAvailability(false)).called(1);
+
+        // But the resolved mode has not been applied yet -- still inside the
+        // debounce window.
+        verifyNever(() => destination.setMode(any()));
+
+        // After the window closes, the override wins -- ResolvedStreaming is
+        // applied. (ResolvedOffline would have been applied if the network
+        // event drove resolution; the override suppresses that.)
+        async.elapse(const Duration(seconds: 1));
+        verify(() => destination.setMode(const ResolvedStreaming())).called(1);
+
+        connectionManager.dispose();
+      });
+    });
+
+    test(
+        'initialApplicationState seeds the lifecycle assumption so the SDK '
+        'does not default to foreground when launched in background', () {
+      // The manager is constructed with `initialApplicationState: background`.
+      // Toggling `offline` forces a synchronous `_handleState` -- with the
+      // seed in effect, the resolved automatic mode reflects the
+      // background + runInBackground=false state and yields
+      // ResolvedOffline(OfflineBackgroundDisabled). Without the seed
+      // (i.e., defaulted to foreground) the result would fall through to
+      // the foreground slot and yield ResolvedStreaming.
+      registerFallbackValue(ConnectionMode.streaming);
+
+      final destination = MockDestination();
+      final logAdapter = MockLogAdapter();
+      final logger = LDLogger(adapter: logAdapter);
+      final config = ConnectionManagerConfig(
+        runInBackground: false,
+        debounceWindow: const Duration(seconds: 1),
+        initialApplicationState: ApplicationState.background,
+      );
+      final mockDetector = MockStateDetector();
+
+      final connectionManager = ConnectionManager(
+        logger: logger,
+        config: config,
+        destination: destination,
+        detector: mockDetector,
+      );
+
+      connectionManager.offline = true;
+      reset(destination);
+      connectionManager.offline = false;
+
+      verify(() => destination.setMode(
+          const ResolvedOffline(OfflineBackgroundDisabled()))).called(1);
+
+      connectionManager.dispose();
+    });
+
+    test(
+        'initialApplicationState seeded to background drives the buffered '
+        'initial reconcile to the correct mode without any external trigger '
+        '(round-1 background-launch regression)', () async {
+      // Regression for the round-1 bug: a background-launched SDK whose
+      // initial lifecycle state is known synchronously should have the
+      // correct resolved mode applied to the destination via the
+      // debouncer's buffered initial reconcile -- no offline toggle, no
+      // detector emission, no waiting on the debounce window.
+      registerFallbackValue(ConnectionMode.streaming);
+
+      final destination = MockDestination();
+      final logAdapter = MockLogAdapter();
+      final logger = LDLogger(adapter: logAdapter);
+      final config = ConnectionManagerConfig(
+        runInBackground: false,
+        debounceWindow: const Duration(seconds: 1),
+        initialApplicationState: ApplicationState.background,
+      );
+      final mockDetector = MockStateDetector();
+
+      final connectionManager = ConnectionManager(
+        logger: logger,
+        config: config,
+        destination: destination,
+        detector: mockDetector,
+      );
+
+      // The buffered initial reconcile fires on the next microtask after
+      // construction.
+      await Future<void>.microtask(() {});
+
+      verify(() => destination.setMode(
+          const ResolvedOffline(OfflineBackgroundDisabled()))).called(1);
+      verify(() => destination.setEventSendingEnabled(false, flush: false))
+          .called(1);
+
+      connectionManager.dispose();
+    });
   });
 }


### PR DESCRIPTION
## Summary

Wires `StateDebounceManager` (from `launchdarkly_common_client`) into the Flutter `ConnectionManager`. Lifecycle and network events feed the debouncer rather than driving `_handleState()` directly; the debouncer's stream emits a reconciled snapshot after the configurable window closes (default 1s), at which point `_handleState()` runs once.

Implements CSFDV2 CONNMODE section 3.5 for the Flutter SDK.

### Notable behaviour

- `ConnectionManagerConfig` gains `debounceWindow` and `initialApplicationState`.
- Foreground -> background flush remains synchronous (CONNMODE 3.3.1).
- Network availability propagation to the destination remains synchronous; only the mode-resolution decision is debounced.
- `setMode(mode)` sets the override synchronously so subsequent automatic transitions are suppressed immediately; applying the resolved mode is debounced (CONNMODE 2.0.3 / 3.5.5).
- `FlutterStateDetector` exposes `initialApplicationState`, read synchronously at construction time from `SchedulerBinding.instance.lifecycleState`, so the SDK seeds the correct lifecycle assumption when launched in background.
- `LDClient` wires the seed and substitutes `foreground` when the user opts out of lifecycle handling (`applicationEvents.backgrounding=false`).

## Blocked on

Depends on #291 (StateDebounceManager in common_client). After #291 merges and `launchdarkly_common_client` is released, the pin in `packages/flutter_client_sdk/pubspec.yaml` will be bumped to that version and this PR can be marked ready for review.

Split out of #281 to enable incremental merge / release per the dependency-order workflow in RELEASING.md.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when streaming/polling/offline modes apply during rapid lifecycle and network churn; mis-seeded `initialApplicationState` could mis-resolve mode on background launch, though behavior is heavily tested.
> 
> **Overview**
> Wires **`StateDebounceManager`** from `launchdarkly_common_client` into Flutter **`ConnectionManager`** so lifecycle, network, and **`setMode`** signals coalesce before **`_handleState()`** runs (default **1s** `debounceWindow`; **`Duration.zero`** keeps prior synchronous behavior for tests).
> 
> **`ConnectionManagerConfig`** adds **`debounceWindow`** and **`initialApplicationState`**. Foreground→background **flush** and destination **network availability** updates stay synchronous; explicit **`offline`** still bypasses debouncing. **`setMode`** records the override immediately but debounces applying the resolved mode.
> 
> **`FlutterStateDetector`** exposes **`initialApplicationState`** from **`SchedulerBinding.instance.lifecycleState`**. **`LDClient`** reuses one detector instance, seeds lifecycle when backgrounding is enabled, and stops folding **`config.offline`** into the automatic background/network disable flags (offline is applied via **`_connectionManager.offline`** after construction). Bumps **`launchdarkly_common_client`** to **1.13.0** and extends **`connection_manager_test`** with **`fake_async`** debounce and background-launch regression coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b51ade7368fdf67933591a5fd6ea83bbac4f6938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->