### PR TITLE
feat: Update launchdarkly_event_source_client to version 2.2.0

### DIFF
--- a/packages/common_client/pubspec.yaml
+++ b/packages/common_client/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   http: ^1.1.2
   launchdarkly_dart_common: 1.8.1
-  launchdarkly_event_source_client: 2.1.0
+  launchdarkly_event_source_client: 2.2.0
   crypto: ^3.0.3
   uuid: ">= 3.0.7 <5.0.0"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single dependency pin change with no logic edits; behavior depends on what shipped in event_source_client 2.2.0 elsewhere in the monorepo.
> 
> **Overview**
> Bumps the pinned **`launchdarkly_event_source_client`** dependency in `launchdarkly_common_client` from **2.1.0** to **2.2.0**, so the shared client layer uses the latest in-repo SSE package for streaming flag updates.
> 
> There are **no application code changes** in this PR—only the `pubspec.yaml` version pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49beb02b485c8dfb660983131320f19ff2399d73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->