### PR TITLE
feat: Add FDv2 streaming source factories and query-parameter authentication

### DIFF
--- a/packages/common_client/lib/src/data_sources/fdv2/endpoints.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/endpoints.dart
@@ -1,3 +1,7 @@
+import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart';
+
+import 'selector.dart';
+
 /// FDv2 endpoint paths.
 ///
 /// These paths are uniform across mobile and browser SDKs; FDv2 does
@@ -19,4 +23,40 @@ abstract final class FDv2Endpoints {
   /// embedded in the URL path.
   static String streamingGet(String encodedContext) =>
       '$streaming/$encodedContext';
+}
+
+/// Builds an FDv2 request URI: appends [addedPath] to [baseUri]'s path and
+/// merges the [withReasons], [basis], and [additionalQueryParameters]
+/// query parameters onto the base URL's own.
+///
+/// Composes against the parsed [baseUri] so a custom URL carrying its own
+/// query parameters (e.g. a relay proxy with a token) is preserved --
+/// including repeated keys, via `queryParametersAll`, which a plain
+/// `queryParameters` map would collapse to the last value. String
+/// concatenation against the base would instead land the appended path
+/// inside the query component.
+///
+/// Shared by the polling requestor and the streaming source so the two
+/// transports build URLs identically.
+Uri buildFDv2Uri({
+  required Uri baseUri,
+  required String addedPath,
+  required bool withReasons,
+  required Selector basis,
+  Map<String, String> additionalQueryParameters = const {},
+}) {
+  final mergedPath = appendPath(baseUri.path, addedPath);
+  final mergedQuery = <String, dynamic>{}
+    ..addAll(baseUri.queryParametersAll)
+    ..addAll(additionalQueryParameters);
+  if (withReasons) {
+    mergedQuery['withReasons'] = 'true';
+  }
+  if (basis.state case final state? when state.isNotEmpty) {
+    mergedQuery['basis'] = state;
+  }
+  return baseUri.replace(
+    path: mergedPath,
+    queryParameters: mergedQuery.isEmpty ? null : mergedQuery,
+  );
 }

--- a/packages/common_client/lib/src/data_sources/fdv2/entry_factories.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/entry_factories.dart
@@ -2,9 +2,14 @@ import 'dart:convert';
 
 import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart'
     hide ServiceEndpoints;
+import 'package:launchdarkly_event_source_client/launchdarkly_event_source_client.dart';
 
+import '../../config/defaults/default_config.dart';
 import '../../config/service_endpoints.dart';
+import '../streaming_data_source.dart' show LDLoggerToEventSourceAdapter;
 import 'cache_initializer.dart' as cache_src;
+import 'endpoints.dart';
+import 'protocol_types.dart';
 import 'source_factory_context.dart';
 import 'mode_definition.dart' as mode;
 import 'polling_base.dart';
@@ -13,6 +18,8 @@ import 'polling_synchronizer.dart';
 import 'requestor.dart';
 import 'selector.dart';
 import 'source.dart';
+import 'streaming_base.dart';
+import 'streaming_synchronizer.dart';
 
 /// Merges per-entry [mode.EndpointConfig] overrides into [base].
 ServiceEndpoints mergeServiceEndpoints(
@@ -50,6 +57,7 @@ FDv2PollingBase _buildPollingBase({
     contextJson: ctx.contextJson,
     usePost: usePost,
     withReasons: ctx.withReasons,
+    additionalQueryParameters: ctx.additionalQueryParameters,
     httpProperties: ctx.httpProperties,
     httpClientFactory: ctx.httpClientFactory ?? _defaultHttpClientFactory,
   );
@@ -61,6 +69,69 @@ FDv2PollingBase _buildPollingBase({
 
 HttpClient _defaultHttpClientFactory(HttpProperties httpProperties) {
   return HttpClient(httpProperties: httpProperties);
+}
+
+/// Constructs the [SSEClient] used by a streaming source. [uriProvider]
+/// is re-invoked on every connection attempt so the `basis` query
+/// parameter reflects the current selector. Tests inject a fake.
+typedef FDv2SseClientFactory = SSEClient Function({
+  required Uri Function() uriProvider,
+  required HttpProperties httpProperties,
+  required String? body,
+  required SseHttpMethod method,
+  required EventSourceLogger logger,
+});
+
+/// FDv2 event names subscribed on the streaming connection. Includes the
+/// legacy `ping` bridge event.
+const Set<String> _fdv2StreamEventNames = {
+  FDv2EventTypes.serverIntent,
+  FDv2EventTypes.putObject,
+  FDv2EventTypes.deleteObject,
+  FDv2EventTypes.payloadTransferred,
+  FDv2EventTypes.goodbye,
+  FDv2EventTypes.error,
+  FDv2EventTypes.heartbeat,
+  'ping',
+};
+
+/// Constructs the production [SSEClient]. The default for the factory
+/// builders; tests inject a fake through the same parameter.
+SSEClient defaultSseClientFactory({
+  required Uri Function() uriProvider,
+  required HttpProperties httpProperties,
+  required String? body,
+  required SseHttpMethod method,
+  required EventSourceLogger logger,
+}) {
+  return SSEClient(uriProvider(), _fdv2StreamEventNames,
+      headers: httpProperties.baseHeaders,
+      body: body,
+      httpMethod: method,
+      logger: logger,
+      uriProvider: uriProvider);
+}
+
+/// Builds the streaming URI for the current state. Invoked per
+/// connection attempt so the `basis` parameter tracks the selector.
+Uri _buildStreamingUri({
+  required ServiceEndpoints endpoints,
+  required String contextEncoded,
+  required bool usePost,
+  required bool withReasons,
+  required Selector basis,
+  Map<String, String> additionalQueryParameters = const {},
+}) {
+  final addedPath = usePost
+      ? FDv2Endpoints.streaming
+      : FDv2Endpoints.streamingGet(contextEncoded);
+  return buildFDv2Uri(
+    baseUri: Uri.parse(endpoints.streaming),
+    addedPath: addedPath,
+    withReasons: withReasons,
+    basis: basis,
+    additionalQueryParameters: additionalQueryParameters,
+  );
 }
 
 /// A factory for creating [Initializer] instances.
@@ -130,12 +201,11 @@ InitializerFactory createInitializerFactoryFromEntry(
 }
 
 /// Builds a [SynchronizerFactory] for a single [mode.SynchronizerEntry].
-///
-/// Throws [UnsupportedError] for unsupported entry types.
 SynchronizerFactory createSynchronizerFactoryFromEntry(
   mode.SynchronizerEntry entry,
-  SourceFactoryContext ctx,
-) {
+  SourceFactoryContext ctx, {
+  FDv2SseClientFactory sseClientFactory = defaultSseClientFactory,
+}) {
   switch (entry) {
     case final mode.PollingSynchronizer e:
       final interval = e.pollInterval ?? ctx.defaultPollingInterval;
@@ -155,9 +225,47 @@ SynchronizerFactory createSynchronizerFactoryFromEntry(
           );
         },
       );
-    case mode.StreamingSynchronizer():
-      throw UnsupportedError(
-        'FDv2 StreamingSynchronizer factories are not implemented yet',
+    case final mode.StreamingSynchronizer e:
+      return SynchronizerFactory(
+        create: (SelectorGetter selectorGetter) {
+          final endpointsResolved =
+              mergeServiceEndpoints(ctx.serviceEndpoints, e.endpoints);
+          Uri uriProvider() => _buildStreamingUri(
+                endpoints: endpointsResolved,
+                contextEncoded: base64UrlEncode(utf8.encode(ctx.contextJson)),
+                usePost: e.usePost,
+                withReasons: ctx.withReasons,
+                basis: selectorGetter(),
+                additionalQueryParameters: ctx.additionalQueryParameters,
+              );
+          final sseClient = sseClientFactory(
+            uriProvider: uriProvider,
+            httpProperties: ctx.httpProperties,
+            body: e.usePost ? ctx.contextJson : null,
+            method: e.usePost ? SseHttpMethod.post : SseHttpMethod.get,
+            logger: LDLoggerToEventSourceAdapter(ctx.logger),
+          );
+
+          // Legacy ping events trigger a one-shot poll.
+          final pingPollingBase = _buildPollingBase(
+            endpoints: e.endpoints,
+            usePost: e.usePost,
+            ctx: ctx,
+          );
+
+          return FDv2StreamingSynchronizer(
+            base: FDv2StreamingBase(
+              sseClient: sseClient,
+              pingHandler: () =>
+                  pingPollingBase.pollOnce(basis: selectorGetter()),
+              logger: ctx.logger,
+              // Used when the transport exposes no response headers (the
+              // browser EventSource) to read x-ld-envid from.
+              defaultEnvironmentId: DefaultConfig.credentialConfig
+                  .environmentIdFallback(ctx.credential),
+            ),
+          );
+        },
       );
   }
 }
@@ -173,9 +281,11 @@ List<InitializerFactory> buildInitializerFactories(
 /// One factory per entry, in list order.
 List<SynchronizerFactory> buildSynchronizerFactories(
   List<mode.SynchronizerEntry> entries,
-  SourceFactoryContext ctx,
-) {
+  SourceFactoryContext ctx, {
+  FDv2SseClientFactory sseClientFactory = defaultSseClientFactory,
+}) {
   return entries
-      .map((e) => createSynchronizerFactoryFromEntry(e, ctx))
+      .map((e) => createSynchronizerFactoryFromEntry(e, ctx,
+          sseClientFactory: sseClientFactory))
       .toList();
 }

--- a/packages/common_client/lib/src/data_sources/fdv2/requestor.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/requestor.dart
@@ -1,5 +1,7 @@
-import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart';
+import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart'
+    hide ServiceEndpoints;
 
+import '../../config/service_endpoints.dart';
 import 'endpoints.dart';
 import 'selector.dart';
 
@@ -39,6 +41,7 @@ final class FDv2Requestor {
   final String _contextJson;
   final bool _usePost;
   final bool _withReasons;
+  final Map<String, String> _additionalQueryParameters;
   String? _lastEtag;
 
   FDv2Requestor({
@@ -49,6 +52,7 @@ final class FDv2Requestor {
     required bool usePost,
     required bool withReasons,
     required HttpProperties httpProperties,
+    Map<String, String> additionalQueryParameters = const {},
     HttpClientFactory httpClientFactory = _defaultHttpClientFactory,
   })  : _logger = logger.subLogger('FDv2Requestor'),
         _baseUri = Uri.parse(endpoints.polling),
@@ -56,6 +60,7 @@ final class FDv2Requestor {
         _contextJson = contextJson,
         _usePost = usePost,
         _withReasons = withReasons,
+        _additionalQueryParameters = additionalQueryParameters,
         _client = httpClientFactory(usePost
             ? httpProperties.withHeaders({'content-type': 'application/json'})
             : httpProperties);
@@ -111,30 +116,12 @@ final class FDv2Requestor {
     final addedPath = _usePost
         ? FDv2Endpoints.polling
         : FDv2Endpoints.pollingGet(_contextEncoded);
-
-    // Compose against the parsed base URI so a custom polling URL
-    // carrying its own query parameters (e.g. a relay proxy with a token)
-    // is preserved correctly. String concatenation against `_baseUri`
-    // would land the appended path inside the query component.
-    final basePath = _baseUri.path.endsWith('/')
-        ? _baseUri.path.substring(0, _baseUri.path.length - 1)
-        : _baseUri.path;
-    final mergedPath = '$basePath$addedPath';
-
-    // Use queryParametersAll so a base URL like `?dup=1&dup=2` round-trips
-    // both values; the simpler `queryParameters` map collapses duplicates.
-    final mergedQuery = <String, dynamic>{};
-    mergedQuery.addAll(_baseUri.queryParametersAll);
-    if (_withReasons) {
-      mergedQuery['withReasons'] = 'true';
-    }
-    if (basis.state case final state? when state.isNotEmpty) {
-      mergedQuery['basis'] = state;
-    }
-
-    return _baseUri.replace(
-      path: mergedPath,
-      queryParameters: mergedQuery.isEmpty ? null : mergedQuery,
+    return buildFDv2Uri(
+      baseUri: _baseUri,
+      addedPath: addedPath,
+      withReasons: _withReasons,
+      basis: basis,
+      additionalQueryParameters: _additionalQueryParameters,
     );
   }
 }

--- a/packages/common_client/lib/src/data_sources/fdv2/source_factory_context.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/source_factory_context.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart'
     hide ServiceEndpoints;
 
+import '../../config/defaults/default_config.dart';
 import '../../config/service_endpoints.dart';
 import 'cache_initializer.dart';
 import 'requestor.dart';
@@ -29,6 +30,14 @@ final class SourceFactoryContext {
 
   final HttpClientFactory? httpClientFactory;
 
+  /// The SDK credential. Used as the environment identifier when the
+  /// platform's credential is a client-side ID.
+  final String credential;
+
+  /// Additional query parameters applied to every data acquisition
+  /// request, both polling and streaming.
+  final Map<String, String> additionalQueryParameters;
+
   const SourceFactoryContext({
     required this.context,
     required this.logger,
@@ -38,6 +47,8 @@ final class SourceFactoryContext {
     required this.withReasons,
     required this.defaultPollingInterval,
     required this.cachedFlagsReader,
+    required this.credential,
+    this.additionalQueryParameters = const {},
     this.httpClientFactory,
   });
 
@@ -49,6 +60,7 @@ final class SourceFactoryContext {
     required bool withReasons,
     required Duration defaultPollingInterval,
     required CachedFlagsReader cachedFlagsReader,
+    required String credential,
     HttpClientFactory? httpClientFactory,
   }) {
     final plainContextString =
@@ -62,6 +74,13 @@ final class SourceFactoryContext {
       withReasons: withReasons,
       defaultPollingInterval: defaultPollingInterval,
       cachedFlagsReader: cachedFlagsReader,
+      credential: credential,
+      // Platforms that authenticate with the `auth` query parameter
+      // (browsers) supply it here; platforms that authenticate with the
+      // authorization header in the base headers (mobile keys) supply
+      // nothing.
+      additionalQueryParameters:
+          DefaultConfig.credentialConfig.authQueryParameters(credential),
       httpClientFactory: httpClientFactory,
     );
   }

--- a/packages/common_client/lib/src/data_sources/fdv2/streaming_base.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/streaming_base.dart
@@ -65,9 +65,11 @@ final class FDv2StreamingBase {
     required SSEClient sseClient,
     required PingHandler pingHandler,
     required LDLogger logger,
+    String? defaultEnvironmentId,
     DateTime Function()? now,
   })  : _sseClient = sseClient,
         _pingHandler = pingHandler,
+        _environmentId = defaultEnvironmentId,
         _logger = logger.subLogger('FDv2StreamingBase'),
         _now = now ?? DateTime.now {
     _controller = StreamController<FDv2SourceResult>(
@@ -314,6 +316,24 @@ final class FDv2StreamingBase {
 
   void _handleSseError(Object err, StackTrace stack) {
     if (_stoppedSignal.isCompleted) return;
+
+    if (err is UnrecoverableStatusError) {
+      // The SSE client stops reconnecting for these status codes, so the
+      // source cannot recover on its own. Surface a terminal error so the
+      // orchestrator moves to another source. The error response may also
+      // carry the FDv1 fallback directive.
+      final fallback = err.headers['x-ld-fd-fallback']?.toLowerCase() == 'true';
+      _logger.warn(
+          'Streaming request failed with status ${err.statusCode}; giving up');
+      _terminate(
+          finalResult: FDv2SourceResults.terminalError(
+        message: 'Streaming request failed with status ${err.statusCode}',
+        statusCode: err.statusCode,
+        fdv1Fallback: fallback,
+      ));
+      return;
+    }
+
     // The SSE client's built-in backoff handles reconnection. Surface
     // the disruption as interrupted; the orchestrator decides whether
     // to fall through to a different source after enough time.

--- a/packages/common_client/test/data_sources/fdv2/entry_factories_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/entry_factories_test.dart
@@ -1,3 +1,5 @@
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:launchdarkly_common_client/src/config/service_endpoints.dart';
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/built_in_modes.dart';
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/cache_initializer.dart';
@@ -7,8 +9,10 @@ import 'package:launchdarkly_common_client/src/data_sources/fdv2/mode_definition
     hide CacheInitializer;
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/payload.dart';
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/polling_synchronizer.dart';
+import 'package:launchdarkly_common_client/src/data_sources/fdv2/streaming_synchronizer.dart';
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/selector.dart';
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/source_result.dart';
+import 'package:launchdarkly_event_source_client/launchdarkly_event_source_client.dart';
 import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart'
     hide ServiceEndpoints;
 import 'package:test/test.dart';
@@ -22,6 +26,7 @@ SourceFactoryContext _testContext({
   Duration? defaultPollingInterval,
 }) {
   return SourceFactoryContext.fromClientConfig(
+    credential: 'test-credential',
     context: _context(),
     logger: LDLogger(level: LDLogLevel.error),
     httpProperties: HttpProperties(),
@@ -113,12 +118,110 @@ void main() {
       sync.close();
     });
 
-    test('streaming synchronizer is unsupported', () {
+    test('builds factory whose create returns FDv2StreamingSynchronizer', () {
       final ctx = _testContext();
-      expect(
-        () => createSynchronizerFactoryFromEntry(StreamingSynchronizer(), ctx),
-        throwsA(isA<UnsupportedError>()),
+      final factory =
+          createSynchronizerFactoryFromEntry(StreamingSynchronizer(), ctx);
+      final sync = factory.create(_selectorGetter);
+      expect(sync, isA<FDv2StreamingSynchronizer>());
+      sync.close();
+    });
+
+    test(
+        'streaming URI carries the auth query parameters and the current '
+        'basis', () {
+      final ctx = SourceFactoryContext(
+        context: _context(),
+        credential: 'the-client-side-id',
+        additionalQueryParameters: const {'auth': 'the-client-side-id'},
+        logger: LDLogger(level: LDLogLevel.error),
+        httpProperties: HttpProperties(),
+        serviceEndpoints: ServiceEndpoints.custom(
+            polling: 'https://poll.test', streaming: 'https://stream.test'),
+        contextJson: '{"key":"test","kind":"user"}',
+        withReasons: false,
+        defaultPollingInterval: const Duration(seconds: 300),
+        cachedFlagsReader: (_) async => null,
       );
+
+      var selector = Selector.empty;
+      late Uri Function() capturedUriProvider;
+      final factory = createSynchronizerFactoryFromEntry(
+        StreamingSynchronizer(),
+        ctx,
+        sseClientFactory: ({
+          required Uri Function() uriProvider,
+          required HttpProperties httpProperties,
+          required String? body,
+          required SseHttpMethod method,
+          required EventSourceLogger logger,
+        }) {
+          capturedUriProvider = uriProvider;
+          return SSEClient.testClient(uriProvider(), const {});
+        },
+      );
+      final sync = factory.create(() => selector);
+
+      final initialUri = capturedUriProvider();
+      expect(initialUri.host, equals('stream.test'));
+      expect(initialUri.path, startsWith('/sdk/stream/eval/'));
+      expect(initialUri.queryParameters['auth'], equals('the-client-side-id'));
+      expect(initialUri.queryParameters.containsKey('basis'), isFalse);
+
+      selector = const Selector(state: '(p:abc:1)', version: 1);
+      final reconnectUri = capturedUriProvider();
+      expect(
+          reconnectUri.queryParameters['auth'], equals('the-client-side-id'));
+      expect(reconnectUri.queryParameters['basis'], equals('(p:abc:1)'));
+
+      sync.close();
+    });
+
+    test(
+        'streaming URI preserves repeated query keys on the base URL across '
+        'reconnects', () {
+      final ctx = SourceFactoryContext(
+        context: _context(),
+        credential: 'cid',
+        logger: LDLogger(level: LDLogLevel.error),
+        httpProperties: HttpProperties(),
+        serviceEndpoints: ServiceEndpoints.custom(
+            polling: 'https://poll.test',
+            streaming: 'https://relay.test/?tag=a&tag=b'),
+        contextJson: '{"key":"test","kind":"user"}',
+        withReasons: false,
+        defaultPollingInterval: const Duration(seconds: 300),
+        cachedFlagsReader: (_) async => null,
+      );
+
+      var selector = Selector.empty;
+      late Uri Function() capturedUriProvider;
+      final factory = createSynchronizerFactoryFromEntry(
+        StreamingSynchronizer(),
+        ctx,
+        sseClientFactory: ({
+          required Uri Function() uriProvider,
+          required HttpProperties httpProperties,
+          required String? body,
+          required SseHttpMethod method,
+          required EventSourceLogger logger,
+        }) {
+          capturedUriProvider = uriProvider;
+          return SSEClient.testClient(uriProvider(), const {});
+        },
+      );
+      final sync = factory.create(() => selector);
+
+      // A relay-style base URL with a repeated key must round-trip both
+      // values, matching the polling requestor -- and on every reconnect,
+      // since the provider rebuilds the URI each time.
+      expect(
+          capturedUriProvider().queryParametersAll['tag'], equals(['a', 'b']));
+      selector = const Selector(state: '(p:abc:1)', version: 1);
+      expect(
+          capturedUriProvider().queryParametersAll['tag'], equals(['a', 'b']));
+
+      sync.close();
     });
   });
 
@@ -129,6 +232,37 @@ void main() {
         () => createInitializerFactoryFromEntry(StreamingInitializer(), ctx),
         throwsA(isA<UnsupportedError>()),
       );
+    });
+
+    test('polling request carries the auth query parameters', () async {
+      late Uri capturedUri;
+      final mock = MockClient((request) async {
+        capturedUri = request.url;
+        return http.Response('{"events":[]}', 200);
+      });
+      final ctx = SourceFactoryContext(
+        context: _context(),
+        credential: 'the-client-side-id',
+        additionalQueryParameters: const {'auth': 'the-client-side-id'},
+        logger: LDLogger(level: LDLogLevel.error),
+        httpProperties: HttpProperties(),
+        serviceEndpoints:
+            ServiceEndpoints.custom(polling: 'https://example.test'),
+        contextJson: '{"key":"test","kind":"user"}',
+        withReasons: false,
+        defaultPollingInterval: const Duration(seconds: 300),
+        cachedFlagsReader: (_) async => null,
+        httpClientFactory: (props) =>
+            HttpClient(client: mock, httpProperties: props),
+      );
+
+      final factory =
+          createInitializerFactoryFromEntry(PollingInitializer(), ctx);
+      final init = factory.create(_selectorGetter);
+      await init.run();
+
+      expect(capturedUri.queryParameters,
+          containsPair('auth', 'the-client-side-id'));
     });
   });
 

--- a/packages/common_client/test/data_sources/fdv2/requestor_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/requestor_test.dart
@@ -16,6 +16,7 @@ FDv2Requestor makeRequestor(
   bool withReasons = false,
   String contextEncoded = 'eyJrZXkiOiJ0ZXN0In0=',
   String contextJson = '{"key":"test"}',
+  Map<String, String> additionalQueryParameters = const {},
   HttpProperties? httpProperties,
 }) {
   return FDv2Requestor(
@@ -25,6 +26,7 @@ FDv2Requestor makeRequestor(
     contextJson: contextJson,
     usePost: usePost,
     withReasons: withReasons,
+    additionalQueryParameters: additionalQueryParameters,
     httpProperties: httpProperties ?? HttpProperties(),
     httpClientFactory: (props) =>
         HttpClient(client: innerClient, httpProperties: props),
@@ -56,6 +58,41 @@ void main() {
       expect(capturedMethod, equals('GET'));
       expect(capturedUri.path, equals('/sdk/poll/eval/ENC123'));
       expect(capturedUri.host, equals('example.test'));
+    });
+
+    test('does not add an authorization header', () async {
+      Map<String, String>? capturedHeaders;
+      final mock = MockClient((request) async {
+        capturedHeaders = request.headers;
+        return http.Response('{}', 200);
+      });
+
+      final requestor = makeRequestor(mock);
+      await requestor.request();
+
+      expect(capturedHeaders, isNot(contains('authorization')),
+          reason: 'authentication comes from the base headers or the '
+              'additional query parameters, never per-request');
+    });
+
+    test('includes the additional query parameters in every request URL',
+        () async {
+      final capturedUris = <Uri>[];
+      final mock = MockClient((request) async {
+        capturedUris.add(request.url);
+        return http.Response('{}', 200);
+      });
+
+      final requestor = makeRequestor(mock,
+          additionalQueryParameters: {'auth': 'the-client-side-id'});
+      await requestor.request();
+      await requestor.request(basis: Selector(state: 'st', version: 1));
+
+      expect(capturedUris, hasLength(2));
+      for (final uri in capturedUris) {
+        expect(uri.queryParameters, containsPair('auth', 'the-client-side-id'));
+      }
+      expect(capturedUris[1].queryParameters, containsPair('basis', 'st'));
     });
 
     test('does not send a body on GET', () async {

--- a/packages/common_client/test/data_sources/fdv2/source_factory_context_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/source_factory_context_test.dart
@@ -23,6 +23,7 @@ void main() {
       Future<CachedFlags?> reader(LDContext _) async => null;
 
       final ctx = SourceFactoryContext.fromClientConfig(
+        credential: 'test-credential',
         context: context,
         logger: logger,
         httpProperties: httpProperties,
@@ -51,6 +52,7 @@ void main() {
       Future<CachedFlags?> reader(LDContext _) async => null;
 
       final ctx = SourceFactoryContext.fromClientConfig(
+        credential: 'test-credential',
         context: context,
         logger: logger,
         httpProperties: HttpProperties(),
@@ -85,6 +87,7 @@ void main() {
       Future<CachedFlags?> reader(LDContext _) async => null;
 
       final ctx = SourceFactoryContext.fromClientConfig(
+        credential: 'test-credential',
         context: context,
         logger: logger,
         httpProperties: HttpProperties(),
@@ -116,6 +119,7 @@ void main() {
           HttpClient(httpProperties: p);
 
       final ctx = SourceFactoryContext.fromClientConfig(
+        credential: 'test-credential',
         context: context,
         logger: logger,
         httpProperties: httpProperties,


### PR DESCRIPTION
> Stacked on #309 (FDv2 source-layer translation); that lands first.

## What this adds

The streaming half of the FDv2 source factories, plus the authentication plumbing both source kinds share. Nothing constructs these factories in production yet (the orchestrator consumes them in a later PR), so behavior is unchanged.

### Streaming factories

`createSynchronizerFactoryFromEntry` now builds `FDv2StreamingSynchronizer`s instead of throwing `UnsupportedError`. The SSE client is constructed with a `uriProvider` that is re-invoked on every connection attempt, so the `basis` query parameter always reflects the current selector — a reconnect after payloads have been applied resumes with a delta request rather than refetching the full payload. The URI builder composes against the configured base URI the same way the polling requestor does (path joining without clobbering existing query parameters).

### Query-parameter authentication

`SourceFactoryContext` gains `additionalQueryParameters`, applied to every data acquisition request by both FDv2 transports — streaming through the `uriProvider`, and polling through `FDv2Requestor`, which merges them into each poll URL. The transports are agnostic about what the parameters carry; authentication enters at the single population site, where `SourceFactoryContext.fromClientConfig` supplies the platform `CredentialConfig.authQueryParameters`: empty on io (every io transport authenticates with the authorization header in the base headers) and `auth=<client-side-id>` on web.

The web platform authenticates with the query parameter at all times rather than the authorization header: a browser only delivers that header when the target service's CORS pre-flight allows it, the browser's native `EventSource` cannot send custom headers at all, and the FDv2 endpoint paths do not embed the credential the way the FDv1 client-side paths do. (Requirement 3.1.3 of the client-side FDv2 spec, added in launchdarkly/sdk-specs#233, permits this.) Verified against the live service: the FDv2 polling endpoint returns 200 with `?auth=<credential>` and 400 without.

## Testing

Factory tests cover the streaming construction path and pin the URI contract: the streaming URI carries the auth query parameters and picks up the current selector's `basis` on each provider invocation, and the polling request URL carries the auth parameters through the factory wiring. Requestor tests assert the additional query parameters appear on every poll URL alongside `basis`, and that the requestor adds no authorization header (authentication comes from base headers or query parameters, never per-request). Full package suite passes.

SDK-2186

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication query parameters and streaming connection/error handling; production behavior is unchanged until the orchestrator wires these factories, but mistakes could break web auth or fallback when enabled.
> 
> **Overview**
> Adds **FDv2 streaming synchronizer** factory wiring so `StreamingSynchronizer` entries build `FDv2StreamingSynchronizer` with an SSE client whose **`uriProvider` is rebuilt on each connect**, keeping `basis` aligned with the current selector for delta resumes after reconnect.
> 
> Introduces shared **`buildFDv2Uri`** for polling and streaming so paths, `withReasons`, `basis`, relay-style base query strings (including **duplicate keys**), and extra params merge the same way. **`SourceFactoryContext`** now carries **`credential`** and **`additionalQueryParameters`** (from `CredentialConfig.authQueryParameters`, e.g. web `auth=`), applied on every poll and stream URL via **`FDv2Requestor`** and the streaming URI builder.
> 
> **`FDv2StreamingBase`** gains optional **`defaultEnvironmentId`** when headers are unavailable, and treats **`UnrecoverableStatusError`** as a terminal failure (with optional **`x-ld-fd-fd-fallback`**). Factory and requestor tests cover auth query params, basis on reconnect, and repeated relay query keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 187332ded15c4e930a4c7177a8ebfa1cf3f2ce14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->