### PR TITLE
feat: Add the FDv2 data source orchestrator

### DIFF
--- a/packages/common_client/lib/src/data_sources/data_source.dart
+++ b/packages/common_client/lib/src/data_sources/data_source.dart
@@ -1,4 +1,5 @@
 import 'data_source_status.dart';
+import 'fdv2/payload.dart';
 
 sealed class DataSourceEvent {}
 
@@ -8,6 +9,16 @@ final class DataEvent implements DataSourceEvent {
   final String? environmentId;
 
   DataEvent(this.type, this.data, {this.environmentId});
+}
+
+/// An FDv2 change set produced by the data source orchestrator. Carries
+/// typed flag descriptors translated at acquisition time, not the FDv1
+/// JSON string forms.
+final class PayloadEvent implements DataSourceEvent {
+  final ChangeSet changeSet;
+  final String? environmentId;
+
+  PayloadEvent(this.changeSet, {this.environmentId});
 }
 
 final class StatusEvent implements DataSourceEvent {

--- a/packages/common_client/lib/src/data_sources/data_source_manager.dart
+++ b/packages/common_client/lib/src/data_sources/data_source_manager.dart
@@ -159,6 +159,10 @@ final class DataSourceManager {
           // Only need to complete this the first time.
           _identifyCompleter = null;
           return handled;
+        case PayloadEvent():
+          // The FDv1 data sources this manager runs never produce FDv2
+          // payload events.
+          return MessageStatus.messageHandled;
         case StatusEvent():
           if (_identifyCompleter != null && !_identifyCompleter!.isCompleted) {
             _identifyCompleter!.completeError(Exception(event.message));

--- a/packages/common_client/lib/src/data_sources/fdv2/orchestrator.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/orchestrator.dart
@@ -1,0 +1,415 @@
+import 'dart:async';
+
+import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart'
+    show LDLogger;
+
+import '../data_source.dart';
+import '../data_source_status.dart';
+import '../data_source_status_manager.dart';
+import 'conditions.dart';
+import 'entry_factories.dart';
+import 'payload.dart';
+import 'selector.dart';
+import 'source.dart';
+import 'source_manager.dart';
+import 'source_result.dart';
+
+/// Receives the selector from each applied payload so it can be carried
+/// across data source instances (mode switches, reconnects).
+typedef SelectorUpdater = void Function(Selector selector);
+
+/// Outcome of running a single synchronizer instance, directing what the
+/// synchronizer loop does next.
+enum _SynchronizerOutcome {
+  /// Move to the next available synchronizer.
+  advance,
+
+  /// Re-create the current synchronizer (goodbye or restart request).
+  recycle,
+
+  /// Reset to the primary synchronizer (recovery condition fired).
+  recover,
+
+  /// Stop the orchestration loop entirely.
+  stop,
+}
+
+/// The FDv2 data source orchestrator.
+///
+/// Runs the initializer chain to bring the SDK to a usable state, then
+/// drives the synchronizer tier with fallback and recovery transitions.
+/// Implements the existing [DataSource] interface so the
+/// DataSourceManager pipeline consumes it unchanged: change sets are
+/// emitted as [PayloadEvent]s, and a [StatusEvent] with `shutdown: true`
+/// is emitted only when the data system halts without having delivered
+/// data. Transient interruptions are reported directly through the
+/// [DataSourceStatusManager], matching the FDv1 streaming source's
+/// behavior of not failing an in-flight identify for recoverable errors.
+final class FDv2DataSourceOrchestrator implements DataSource {
+  final SourceManager _sourceManager;
+  final List<InitializerFactory> _initializerFactories;
+  final List<SynchronizerSlot> _synchronizerSlots;
+  final SelectorUpdater _selectorUpdater;
+  final DataSourceStatusManager _statusManager;
+  final Duration _fallbackTimeout;
+  final Duration _recoveryTimeout;
+  final Duration _recycleDelay;
+  final LDLogger _logger;
+
+  final StreamController<DataSourceEvent> _controller =
+      StreamController<DataSourceEvent>();
+
+  bool _started = false;
+  bool _closed = false;
+  bool _emittedPayload = false;
+
+  /// Resolves the outcome of the active synchronizer run. Set while a
+  /// synchronizer is running; [restart] and [stop] use it to interrupt
+  /// the run.
+  void Function(_SynchronizerOutcome outcome)? _resolveCurrentOutcome;
+
+  FDv2DataSourceOrchestrator({
+    required List<InitializerFactory> initializerFactories,
+    required List<SynchronizerSlot> synchronizerSlots,
+    required SelectorGetter selectorGetter,
+    required SelectorUpdater selectorUpdater,
+    required DataSourceStatusManager statusManager,
+    required LDLogger logger,
+    Duration fallbackTimeout = defaultFallbackTimeout,
+    Duration recoveryTimeout = defaultRecoveryTimeout,
+    Duration recycleDelay = const Duration(seconds: 1),
+  })  : _initializerFactories = initializerFactories,
+        _synchronizerSlots = synchronizerSlots,
+        _selectorUpdater = selectorUpdater,
+        _statusManager = statusManager,
+        _fallbackTimeout = fallbackTimeout,
+        _recoveryTimeout = recoveryTimeout,
+        _recycleDelay = recycleDelay,
+        _logger = logger.subLogger('FDv2Orchestrator'),
+        _sourceManager = SourceManager(
+          initializerFactories: initializerFactories,
+          synchronizerSlots: synchronizerSlots,
+          selectorGetter: selectorGetter,
+        );
+
+  @override
+  Stream<DataSourceEvent> get events => _controller.stream;
+
+  @override
+  void start() {
+    if (_started || _closed) {
+      return;
+    }
+    _started = true;
+    unawaited(_run());
+  }
+
+  @override
+  void stop() {
+    if (_closed) return;
+    _closed = true;
+    _sourceManager.close();
+    // Wake the active synchronizer run so it can observe the closed
+    // state.
+    _resolveCurrentOutcome?.call(_SynchronizerOutcome.stop);
+    if (!_controller.isClosed) {
+      _controller.close();
+    }
+  }
+
+  @override
+  void restart() {
+    if (_closed) return;
+    _logger.debug('Restart requested; recycling the active synchronizer.');
+    _resolveCurrentOutcome?.call(_SynchronizerOutcome.recycle);
+  }
+
+  Future<void> _run() async {
+    try {
+      await _runInitializers();
+      if (!_closed) {
+        await _runSynchronizers();
+      }
+    } catch (err, stack) {
+      _logger.error('Orchestration raised unexpectedly: ${err.runtimeType}');
+      _logger.debug('Orchestration error stack:\n$stack');
+      _halt('FDv2 data system encountered an unexpected error');
+    }
+  }
+
+  void _emitPayload(ChangeSetResult result) {
+    if (_closed || _controller.isClosed) return;
+    // An intent of "none" means the SDK is already up to date; it carries
+    // no selector and must not regress the one we hold. For any other
+    // type the payload's selector is adopted verbatim, including an empty
+    // one -- a selector-less full transfer (an FDv1 fallback payload,
+    // whose state cannot serve as an FDv2 basis) must clear the held
+    // selector so the next request sends no stale basis. Do not gate this
+    // on a non-empty selector.
+    if (result.changeSet.type != PayloadType.none) {
+      _selectorUpdater(result.changeSet.selector);
+    }
+    _emittedPayload = true;
+    _controller.add(
+        PayloadEvent(result.changeSet, environmentId: result.environmentId));
+  }
+
+  void _reportTransientError(StatusResult result) {
+    final message = result.message ?? 'FDv2 data source reported an error';
+    if (result.statusCode case final statusCode?) {
+      _statusManager.setErrorResponse(statusCode, message);
+    } else {
+      _statusManager.setErrorByKind(ErrorKind.networkError, message);
+    }
+  }
+
+  /// Halts the data system. Emits a shutdown status event so a pending
+  /// identify fails and the status reflects that no further data will
+  /// arrive.
+  void _halt(String message) {
+    if (_closed || _controller.isClosed) return;
+    _logger.warn('FDv2 data system halted: $message');
+    _controller
+        .add(StatusEvent(ErrorKind.unknown, null, message, shutdown: true));
+  }
+
+  /// True when the source indicated an FDv1 fallback directive and a
+  /// fallback tier exists to engage.
+  bool _handleFdv1Fallback(FDv2SourceResult result) {
+    if (result.fdv1Fallback && _sourceManager.hasFdv1FallbackConfigured) {
+      _logger.warn('Server directed fallback to FDv1; engaging the FDv1 '
+          'fallback synchronizer.');
+      _sourceManager.engageFdv1Fallback();
+      return true;
+    }
+    return false;
+  }
+
+  Future<void> _runInitializers() async {
+    var errorDuringInit = false;
+
+    while (!_closed) {
+      final initializer = _sourceManager.nextInitializer();
+      if (initializer == null) {
+        break;
+      }
+
+      final result = await initializer.run();
+      if (_closed) return;
+
+      switch (result) {
+        case ChangeSetResult():
+          if (result.changeSet.type != PayloadType.none) {
+            _emitPayload(result);
+
+            if (_handleFdv1Fallback(result)) {
+              // Data was received but the server directed FDv1 fallback;
+              // move on to synchronizers where the fallback tier runs.
+              return;
+            }
+
+            if (result.changeSet.selector.isNotEmpty) {
+              // Basis data with a selector: initialization is complete.
+              return;
+            }
+            // Data without a selector (e.g. cache); keep initializing.
+          }
+        case StatusResult():
+          switch (result.state) {
+            case SourceState.interrupted:
+            case SourceState.terminalError:
+              _logger.warn('Initializer failed: '
+                  '${result.message ?? 'unknown error'}');
+              _reportTransientError(result);
+              errorDuringInit = true;
+            case SourceState.shutdown:
+              return;
+            case SourceState.goodbye:
+              break;
+          }
+          if (_handleFdv1Fallback(result)) {
+            return;
+          }
+      }
+    }
+
+    if (_closed) return;
+
+    // All initializers exhausted. A data system whose only sources are
+    // cache initializers must still complete initialization on a cache
+    // miss -- there is nowhere else for data to come from. Emit an empty
+    // payload so the pipeline reaches a valid state, unless an error has
+    // already been reported.
+    final cacheOnlyDataSystem = _initializerFactories.isNotEmpty &&
+        _initializerFactories.every((f) => f.isCache) &&
+        _synchronizerSlots.isEmpty;
+    if (cacheOnlyDataSystem && !_emittedPayload && !errorDuringInit) {
+      _emitPayload(const ChangeSetResult(
+        changeSet: ChangeSet(type: PayloadType.none, updates: {}),
+        persist: false,
+      ));
+    }
+  }
+
+  Future<void> _runSynchronizers() async {
+    // A data system with no sources at all has nothing to do; an empty
+    // payload marks it valid so a pending identify completes.
+    if (_initializerFactories.isEmpty && _synchronizerSlots.isEmpty) {
+      _emitPayload(const ChangeSetResult(
+        changeSet: ChangeSet(type: PayloadType.none, updates: {}),
+        persist: false,
+      ));
+      return;
+    }
+
+    Synchronizer? synchronizer;
+    var recycleCurrent = false;
+
+    while (!_closed) {
+      if (recycleCurrent) {
+        recycleCurrent = false;
+        if (_recycleDelay > Duration.zero) {
+          await Future<void>.delayed(_recycleDelay);
+          if (_closed) return;
+        }
+        synchronizer = _sourceManager.recreateCurrentSynchronizer();
+      } else {
+        synchronizer = _sourceManager.nextAvailableSynchronizer();
+      }
+
+      if (synchronizer == null) {
+        if (!_emittedPayload) {
+          _halt('All FDv2 data sources exhausted without receiving data');
+        } else if (_synchronizerSlots.isNotEmpty) {
+          _logger.warn('No available FDv2 synchronizer remains; the SDK '
+              'will not receive further updates.');
+        }
+        return;
+      }
+
+      final outcome = await _runSynchronizer(synchronizer);
+      switch (outcome) {
+        case _SynchronizerOutcome.advance:
+          break;
+        case _SynchronizerOutcome.recycle:
+          recycleCurrent = true;
+        case _SynchronizerOutcome.recover:
+          _sourceManager.resetSynchronizerIndex();
+        case _SynchronizerOutcome.stop:
+          return;
+      }
+    }
+  }
+
+  /// Runs a single synchronizer instance until something decides its
+  /// outcome.
+  ///
+  /// Consumption is subscription-driven: one listener on the
+  /// synchronizer's results, one on the merged condition stream, and a
+  /// resolve hook for [restart] and [stop]. Nothing is attached
+  /// per-result, so a healthy synchronizer that streams change sets
+  /// indefinitely holds constant memory. (Racing long-lived futures per
+  /// result would attach an irremovable listener to them each
+  /// iteration; future listeners are only released on completion.)
+  Future<_SynchronizerOutcome> _runSynchronizer(
+      Synchronizer synchronizer) async {
+    final conditions = getConditions(
+      availableSynchronizerCount: _sourceManager.availableSynchronizerCount,
+      isPrimary: _sourceManager.isPrimarySynchronizer,
+      fallbackTimeout: _fallbackTimeout,
+      recoveryTimeout: _recoveryTimeout,
+    );
+
+    final outcome = Completer<_SynchronizerOutcome>();
+    void resolve(_SynchronizerOutcome decision) {
+      if (!outcome.isCompleted) {
+        outcome.complete(decision);
+      }
+    }
+
+    _resolveCurrentOutcome = resolve;
+
+    final conditionSubscription = conditions.events.listen((type) {
+      switch (type) {
+        case ConditionType.fallback:
+          _logger.warn('Fallback condition fired; moving to the next '
+              'synchronizer.');
+          resolve(_SynchronizerOutcome.advance);
+        case ConditionType.recovery:
+          _logger.info('Recovery condition fired; returning to the '
+              'primary synchronizer.');
+          resolve(_SynchronizerOutcome.recover);
+      }
+    });
+
+    final resultSubscription = synchronizer.results.listen((result) {
+      if (outcome.isCompleted || _closed) return;
+
+      conditions.inform(result);
+
+      switch (result) {
+        case ChangeSetResult():
+          _emitPayload(result);
+        case StatusResult():
+          switch (result.state) {
+            case SourceState.interrupted:
+              _logger.warn('Synchronizer interrupted: '
+                  '${result.message ?? 'unknown error'}');
+              _reportTransientError(result);
+            case SourceState.terminalError:
+              _logger.warn('Synchronizer terminal error: '
+                  '${result.message ?? 'unknown error'}');
+              _reportTransientError(result);
+              if (_handleFdv1Fallback(result)) {
+                resolve(_SynchronizerOutcome.advance);
+                return;
+              }
+              _sourceManager.blockCurrentSynchronizer();
+              resolve(_SynchronizerOutcome.advance);
+              return;
+            case SourceState.shutdown:
+              // A synchronizer that shuts itself down before the system
+              // has reached a usable state would otherwise leave a
+              // pending identify with nothing to resolve it. Emit a
+              // shutdown status so identify fails rather than hangs,
+              // mirroring the source-exhaustion path. (No shipped source
+              // reaches here while the system is still live, but a future
+              // synchronizer could.)
+              if (!_emittedPayload) {
+                _halt('FDv2 synchronizer shut down without delivering data');
+              }
+              resolve(_SynchronizerOutcome.stop);
+              return;
+            case SourceState.goodbye:
+              _logger.info('Server requested disconnect (goodbye); '
+                  're-establishing the synchronizer.');
+              resolve(_SynchronizerOutcome.recycle);
+              return;
+          }
+      }
+
+      if (_handleFdv1Fallback(result)) {
+        resolve(_SynchronizerOutcome.advance);
+      }
+    }, onDone: () {
+      if (outcome.isCompleted || _closed) return;
+      // The stream ended without a directive. Terminal paths emit a
+      // final result first, which is handled above, so this indicates
+      // the source shut itself down unexpectedly. Re-establish it.
+      _logger.warn('Synchronizer stream ended unexpectedly; '
+          're-establishing.');
+      resolve(_SynchronizerOutcome.recycle);
+    });
+
+    try {
+      final decision = await outcome.future;
+      return _closed ? _SynchronizerOutcome.stop : decision;
+    } finally {
+      _resolveCurrentOutcome = null;
+      conditions.close();
+      await conditionSubscription.cancel();
+      await resultSubscription.cancel();
+      synchronizer.close();
+    }
+  }
+}

--- a/packages/common_client/lib/src/data_sources/polling_data_source.dart
+++ b/packages/common_client/lib/src/data_sources/polling_data_source.dart
@@ -116,6 +116,9 @@ final class PollingDataSource implements DataSource {
           _permanentShutdown = true;
           stop();
         }
+      case PayloadEvent():
+        // The FDv1 requestor never produces FDv2 payload events.
+        break;
     }
 
     _schedulePoll();

--- a/packages/common_client/lib/src/data_sources/streaming_data_source.dart
+++ b/packages/common_client/lib/src/data_sources/streaming_data_source.dart
@@ -173,6 +173,9 @@ final class StreamingDataSource implements DataSource {
                     : res.message;
                 _logger.error('$message: $argument');
                 _dataController.sink.add(res);
+              case PayloadEvent():
+                // The FDv1 requestor never produces FDv2 payload events.
+                break;
             }
           } else {
             _logger.debug('Received message event, data: ${event.data}');

--- a/packages/common_client/test/data_sources/fdv2/orchestrator_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/orchestrator_test.dart
@@ -1,0 +1,602 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:launchdarkly_common_client/src/data_sources/data_source.dart';
+import 'package:launchdarkly_common_client/src/data_sources/data_source_status.dart';
+import 'package:launchdarkly_common_client/src/data_sources/data_source_status_manager.dart';
+import 'package:launchdarkly_common_client/src/data_sources/fdv2/entry_factories.dart';
+import 'package:launchdarkly_common_client/src/data_sources/fdv2/orchestrator.dart';
+import 'package:launchdarkly_common_client/src/data_sources/fdv2/payload.dart';
+import 'package:launchdarkly_common_client/src/data_sources/fdv2/selector.dart';
+import 'package:launchdarkly_common_client/src/data_sources/fdv2/source.dart';
+import 'package:launchdarkly_common_client/src/data_sources/fdv2/source_manager.dart';
+import 'package:launchdarkly_common_client/src/data_sources/fdv2/source_result.dart';
+import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart';
+import 'package:test/test.dart';
+
+final class FakeInitializer implements Initializer {
+  final FDv2SourceResult result;
+  bool closed = false;
+  int runCount = 0;
+
+  FakeInitializer(this.result);
+
+  @override
+  Future<FDv2SourceResult> run() async {
+    runCount += 1;
+    return result;
+  }
+
+  @override
+  void close() {
+    closed = true;
+  }
+}
+
+final class FakeSynchronizer implements Synchronizer {
+  final StreamController<FDv2SourceResult> controller =
+      StreamController<FDv2SourceResult>();
+  bool closed = false;
+
+  @override
+  Stream<FDv2SourceResult> get results => controller.stream;
+
+  @override
+  void close() {
+    closed = true;
+    if (!controller.isClosed) {
+      controller.close();
+    }
+  }
+}
+
+InitializerFactory initializerFactory(FDv2SourceResult result,
+    {bool isCache = false, List<FakeInitializer>? created}) {
+  return InitializerFactory(
+    isCache: isCache,
+    create: (_) {
+      final initializer = FakeInitializer(result);
+      created?.add(initializer);
+      return initializer;
+    },
+  );
+}
+
+SynchronizerSlot synchronizerSlot(List<FakeSynchronizer> created,
+    {bool isFdv1Fallback = false}) {
+  return SynchronizerSlot(
+    isFdv1Fallback: isFdv1Fallback,
+    factory: SynchronizerFactory(create: (_) {
+      final synchronizer = FakeSynchronizer();
+      created.add(synchronizer);
+      return synchronizer;
+    }),
+  );
+}
+
+ChangeSetResult changeSet({
+  Selector selector = Selector.empty,
+  PayloadType type = PayloadType.full,
+  bool fdv1Fallback = false,
+}) {
+  return ChangeSetResult(
+    changeSet: ChangeSet(selector: selector, type: type, updates: const {}),
+    persist: true,
+    fdv1Fallback: fdv1Fallback,
+  );
+}
+
+final class Harness {
+  final List<DataSourceEvent> events = [];
+  final List<Selector> selectorUpdates = [];
+  Selector selector = Selector.empty;
+  late final FDv2DataSourceOrchestrator orchestrator;
+  late final StreamSubscription<DataSourceEvent> subscription;
+
+  Harness({
+    required List<InitializerFactory> initializerFactories,
+    required List<SynchronizerSlot> synchronizerSlots,
+    Duration fallbackTimeout = const Duration(seconds: 120),
+    Duration recoveryTimeout = const Duration(seconds: 300),
+  }) {
+    orchestrator = FDv2DataSourceOrchestrator(
+      initializerFactories: initializerFactories,
+      synchronizerSlots: synchronizerSlots,
+      selectorGetter: () => selector,
+      selectorUpdater: (updated) {
+        selector = updated;
+        selectorUpdates.add(updated);
+      },
+      statusManager: DataSourceStatusManager(),
+      logger: LDLogger(level: LDLogLevel.none),
+      fallbackTimeout: fallbackTimeout,
+      recoveryTimeout: recoveryTimeout,
+      recycleDelay: Duration.zero,
+    );
+    subscription = orchestrator.events.listen(events.add);
+  }
+
+  Future<void> pump([int times = 8]) async {
+    for (var i = 0; i < times; i++) {
+      await Future<void>.delayed(Duration.zero);
+    }
+  }
+}
+
+void main() {
+  test('runs initializers in order until one returns basis data', () async {
+    final firstCreated = <FakeInitializer>[];
+    final secondCreated = <FakeInitializer>[];
+    final thirdCreated = <FakeInitializer>[];
+    final synchronizers = <FakeSynchronizer>[];
+
+    final harness = Harness(initializerFactories: [
+      initializerFactory(FDv2SourceResults.interrupted(message: 'down'),
+          created: firstCreated),
+      initializerFactory(
+          changeSet(selector: const Selector(state: 'state-1', version: 1)),
+          created: secondCreated),
+      initializerFactory(changeSet(), created: thirdCreated),
+    ], synchronizerSlots: [
+      synchronizerSlot(synchronizers),
+    ]);
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    expect(firstCreated.single.runCount, 1);
+    expect(secondCreated.single.runCount, 1);
+    expect(thirdCreated, isEmpty,
+        reason: 'a payload with a selector completes initialization');
+    expect(harness.events.whereType<PayloadEvent>(), hasLength(1));
+    expect(harness.selector.state, 'state-1');
+    expect(synchronizers, hasLength(1),
+        reason: 'the synchronizer tier starts after initialization');
+
+    harness.orchestrator.stop();
+  });
+
+  test('skips data-less results from initializers and keeps going', () async {
+    final synchronizers = <FakeSynchronizer>[];
+    final harness = Harness(initializerFactories: [
+      initializerFactory(changeSet(type: PayloadType.none), isCache: true),
+      initializerFactory(
+          changeSet(selector: const Selector(state: 'state-1', version: 1))),
+    ], synchronizerSlots: [
+      synchronizerSlot(synchronizers),
+    ]);
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    final payloads = harness.events.whereType<PayloadEvent>().toList();
+    expect(payloads, hasLength(1),
+        reason: 'the cache miss payload is not emitted');
+    expect(payloads.single.changeSet.selector.state, 'state-1');
+
+    harness.orchestrator.stop();
+  });
+
+  test(
+      'cache-only data system emits an empty payload on a miss so the SDK '
+      'reaches a usable state', () async {
+    final harness = Harness(initializerFactories: [
+      initializerFactory(changeSet(type: PayloadType.none), isCache: true),
+    ], synchronizerSlots: []);
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    final payloads = harness.events.whereType<PayloadEvent>().toList();
+    expect(payloads, hasLength(1));
+    expect(payloads.single.changeSet.type, PayloadType.none);
+
+    harness.orchestrator.stop();
+  });
+
+  test('synchronizer change sets are emitted and update the selector',
+      () async {
+    final synchronizers = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [synchronizerSlot(synchronizers)],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    synchronizers.single.controller
+        .add(changeSet(selector: const Selector(state: 'state-2', version: 2)));
+    await harness.pump();
+
+    expect(harness.events.whereType<PayloadEvent>(), hasLength(1));
+    expect(harness.selector.state, 'state-2');
+
+    harness.orchestrator.stop();
+  });
+
+  test('a payload of type none does not regress the held selector', () async {
+    final synchronizers = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [synchronizerSlot(synchronizers)],
+    );
+    harness.selector = const Selector(state: 'held', version: 7);
+
+    harness.orchestrator.start();
+    await harness.pump();
+    synchronizers.single.controller.add(changeSet(type: PayloadType.none));
+    await harness.pump();
+
+    expect(harness.selector.state, 'held');
+    expect(harness.events.whereType<PayloadEvent>(), hasLength(1),
+        reason: 'the up-to-date payload still flows through the pipeline');
+
+    harness.orchestrator.stop();
+  });
+
+  test('terminal error blocks the synchronizer and advances to the next',
+      () async {
+    final firstTier = <FakeSynchronizer>[];
+    final secondTier = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [
+        synchronizerSlot(firstTier),
+        synchronizerSlot(secondTier),
+      ],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    firstTier.single.controller
+        .add(FDv2SourceResults.terminalError(message: 'denied'));
+    await harness.pump();
+
+    expect(secondTier, hasLength(1));
+    secondTier.single.controller
+        .add(changeSet(selector: const Selector(state: 's', version: 1)));
+    await harness.pump();
+
+    expect(harness.events.whereType<PayloadEvent>(), hasLength(1));
+
+    harness.orchestrator.stop();
+  });
+
+  test(
+      'a synchronizer stuck on interrupted falls back after the timeout '
+      'instead of retrying the same source forever', () async {
+    final firstTier = <FakeSynchronizer>[];
+    final secondTier = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [
+        synchronizerSlot(firstTier),
+        synchronizerSlot(secondTier),
+      ],
+      fallbackTimeout: const Duration(milliseconds: 50),
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    // The source reports interrupted -- the shape a payload that fails to
+    // translate now takes. The run stays on this source while the
+    // fallback timer counts down; it must not switch immediately.
+    firstTier.single.controller
+        .add(FDv2SourceResults.interrupted(message: 'invalid flag data'));
+    await harness.pump();
+    expect(secondTier, isEmpty,
+        reason: 'fallback waits out the timeout, it does not switch at once');
+
+    // Let the fallback timer elapse. A source that never recovers must not
+    // pin the SDK to it.
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+    await harness.pump();
+
+    expect(secondTier, hasLength(1),
+        reason: 'sustained interruption falls back to the next synchronizer');
+
+    secondTier.single.controller
+        .add(changeSet(selector: const Selector(state: 's', version: 1)));
+    await harness.pump();
+    expect(harness.events.whereType<PayloadEvent>(), hasLength(1));
+
+    harness.orchestrator.stop();
+  });
+
+  test('goodbye re-establishes the same synchronizer', () async {
+    final synchronizers = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [synchronizerSlot(synchronizers)],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    synchronizers.single.controller
+        .add(FDv2SourceResults.goodbyeResult(message: 'bye'));
+    await harness.pump();
+
+    expect(synchronizers, hasLength(2),
+        reason: 'a fresh instance of the same slot is created');
+    expect(synchronizers.first.closed, isTrue);
+
+    harness.orchestrator.stop();
+  });
+
+  test('restart re-establishes the active synchronizer', () async {
+    final synchronizers = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [synchronizerSlot(synchronizers)],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    harness.orchestrator.restart();
+    await harness.pump();
+
+    expect(synchronizers, hasLength(2));
+    expect(synchronizers.first.closed, isTrue);
+
+    harness.orchestrator.stop();
+  });
+
+  test(
+      'halts with a shutdown status when every source is exhausted without '
+      'data', () async {
+    final synchronizers = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [
+        initializerFactory(FDv2SourceResults.interrupted(message: 'down')),
+      ],
+      synchronizerSlots: [synchronizerSlot(synchronizers)],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    synchronizers.single.controller
+        .add(FDv2SourceResults.terminalError(message: 'denied'));
+    await harness.pump();
+
+    final statuses = harness.events.whereType<StatusEvent>().toList();
+    expect(statuses, hasLength(1));
+    expect(statuses.single.shutdown, isTrue);
+    expect(statuses.single.kind, ErrorKind.unknown);
+
+    harness.orchestrator.stop();
+  });
+
+  test(
+      'an FDv1 fallback directive engages the fallback slot and blocks the '
+      'FDv2 synchronizers', () async {
+    final fdv2Tier = <FakeSynchronizer>[];
+    final fdv1Tier = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [
+        synchronizerSlot(fdv2Tier),
+        synchronizerSlot(fdv1Tier, isFdv1Fallback: true),
+      ],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    expect(fdv1Tier, isEmpty, reason: 'the FDv1 slot starts blocked');
+
+    fdv2Tier.single.controller.add(FDv2SourceResults.terminalError(
+        message: 'fall back', fdv1Fallback: true));
+    await harness.pump();
+
+    expect(fdv1Tier, hasLength(1));
+
+    harness.orchestrator.stop();
+  });
+
+  test('recovery condition returns to the primary synchronizer', () async {
+    final primary = <FakeSynchronizer>[];
+    final secondary = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [
+        synchronizerSlot(primary),
+        synchronizerSlot(secondary),
+      ],
+      fallbackTimeout: const Duration(milliseconds: 40),
+      recoveryTimeout: const Duration(milliseconds: 40),
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    // Fall back off the primary (without blocking it) so the secondary,
+    // which carries the recovery condition, runs.
+    primary.single.controller
+        .add(FDv2SourceResults.interrupted(message: 'down'));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    await harness.pump();
+    expect(secondary, hasLength(1),
+        reason: 'the fallback timer moved off the primary');
+
+    // The recovery timer on the non-primary fires and returns to the
+    // primary slot, which is still available.
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    await harness.pump();
+    expect(primary, hasLength(2),
+        reason: 'recovery re-establishes the primary synchronizer');
+
+    harness.orchestrator.stop();
+  });
+
+  test('an unexpectedly ended synchronizer stream is recycled', () async {
+    final synchronizers = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [synchronizerSlot(synchronizers)],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    // The stream ends with no terminal directive -- the source stopped on
+    // its own. The orchestrator recreates the same slot.
+    await synchronizers.single.controller.close();
+    await harness.pump();
+
+    expect(synchronizers, hasLength(2),
+        reason: 'an unexpected stream end recreates the same synchronizer');
+    expect(synchronizers.first.closed, isTrue);
+
+    harness.orchestrator.stop();
+  });
+
+  test(
+      'a synchronizer that shuts down before delivering data halts with a '
+      'shutdown status', () async {
+    final synchronizers = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [synchronizerSlot(synchronizers)],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    synchronizers.single.controller
+        .add(FDv2SourceResults.shutdown(message: 'gone'));
+    await harness.pump();
+
+    final shutdowns =
+        harness.events.whereType<StatusEvent>().where((e) => e.shutdown);
+    expect(shutdowns, hasLength(1),
+        reason: 'a no-data shutdown must surface a shutdown status so a '
+            'pending identify fails instead of hanging');
+
+    harness.orchestrator.stop();
+  });
+
+  test('a synchronizer shutdown after data does not halt the system', () async {
+    final synchronizers = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [synchronizerSlot(synchronizers)],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    synchronizers.single.controller
+        .add(changeSet(selector: const Selector(state: 's', version: 1)));
+    synchronizers.single.controller
+        .add(FDv2SourceResults.shutdown(message: 'gone'));
+    await harness.pump();
+
+    expect(harness.events.whereType<PayloadEvent>(), hasLength(1));
+    expect(harness.events.whereType<StatusEvent>().where((e) => e.shutdown),
+        isEmpty,
+        reason: 'data was already delivered, so a shutdown is not a halt');
+
+    harness.orchestrator.stop();
+  });
+
+  test('an initializer error suppresses the cache-only empty payload',
+      () async {
+    final harness = Harness(
+      initializerFactories: [
+        initializerFactory(
+            FDv2SourceResults.interrupted(message: 'cache read failed'),
+            isCache: true),
+      ],
+      synchronizerSlots: [],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    expect(harness.events.whereType<PayloadEvent>(), isEmpty,
+        reason: 'an errored initialization is not papered over with an empty '
+            'payload, unlike a clean cache miss');
+    expect(harness.events.whereType<StatusEvent>().where((e) => e.shutdown),
+        hasLength(1),
+        reason: 'with no data and no synchronizer tier, the system halts');
+
+    harness.orchestrator.stop();
+  });
+
+  test('stop closes the active synchronizer and ends the loop', () async {
+    final synchronizers = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [synchronizerSlot(synchronizers)],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    harness.orchestrator.stop();
+    await harness.pump();
+
+    expect(synchronizers.single.closed, isTrue);
+    expect(synchronizers, hasLength(1),
+        reason: 'no replacement source is created after stop');
+  });
+
+  test('memory stays bounded while a healthy synchronizer streams results',
+      () async {
+    // A healthy primary that streams change sets indefinitely is the
+    // steady state of a stable connection. Consumption must not attach
+    // anything per-result to long-lived futures or streams: listeners
+    // on a never-completing future cannot be removed, so a per-result
+    // attachment grows for the synchronizer's entire tenure
+    // (measured at roughly 3 KB per result before consumption became
+    // subscription-driven, roughly 100 MB over this soak).
+    Future<int> soak(FakeSynchronizer synchronizer, int results) async {
+      const healthyResult = ChangeSetResult(
+          changeSet: ChangeSet(type: PayloadType.partial, updates: {}),
+          persist: true);
+      final baseline = ProcessInfo.currentRss;
+      for (var i = 0; i < results; i++) {
+        synchronizer.controller.add(healthyResult);
+        await Future<void>.delayed(Duration.zero);
+      }
+      return ProcessInfo.currentRss - baseline;
+    }
+
+    // Two slots so the primary carries a fallback condition; this is
+    // the configuration with the most per-result machinery. The
+    // orchestrator is constructed directly so the emitted payload
+    // events can be discarded instead of retained.
+    final synchronizers = <FakeSynchronizer>[];
+    final orchestrator = FDv2DataSourceOrchestrator(
+      initializerFactories: const [],
+      synchronizerSlots: [
+        synchronizerSlot(synchronizers),
+        synchronizerSlot(synchronizers),
+      ],
+      selectorGetter: () => Selector.empty,
+      selectorUpdater: (_) {},
+      statusManager: DataSourceStatusManager(),
+      logger: LDLogger(level: LDLogLevel.none),
+    );
+    final subscription = orchestrator.events.listen((_) {});
+    orchestrator.start();
+    await Future<void>.delayed(Duration.zero);
+
+    // Warm up allocators before measuring.
+    await soak(synchronizers.single, 2000);
+    final growth = await soak(synchronizers.single, 30000);
+
+    expect(growth, lessThan(25 * 1024 * 1024),
+        reason: 'memory grew ${(growth / 1024 / 1024).toStringAsFixed(1)} MB '
+            'over 30000 results; per-result state is accumulating');
+
+    orchestrator.stop();
+    await subscription.cancel();
+  });
+}

--- a/packages/common_client/test/data_sources/polling_data_source_test.dart
+++ b/packages/common_client/test/data_sources/polling_data_source_test.dart
@@ -65,6 +65,8 @@ class MockLogAdapter extends Mock implements LDLogAdapter {}
           statusManager.setErrorByKind(event.kind, event.message,
               shutdown: event.shutdown);
         }
+      case PayloadEvent():
+        break;
     }
   }).listen((_) {});
 
@@ -440,6 +442,8 @@ void main() {
             statusManager.setErrorByKind(event.kind, event.message,
                 shutdown: event.shutdown);
           }
+        case PayloadEvent():
+          break;
       }
     }).listen((_) {});
 
@@ -501,6 +505,8 @@ void main() {
             statusManager.setErrorByKind(event.kind, event.message,
                 shutdown: event.shutdown);
           }
+        case PayloadEvent():
+          break;
       }
     }).listen((_) {});
 

--- a/packages/common_client/test/data_sources/streaming_data_source_test.dart
+++ b/packages/common_client/test/data_sources/streaming_data_source_test.dart
@@ -96,6 +96,8 @@ class MockSseClient implements SSEClient {
           statusManager.setErrorByKind(event.kind, event.message,
               shutdown: event.shutdown);
         }
+      case PayloadEvent():
+        break;
     }
   }).listen((_) {});
 


### PR DESCRIPTION
> Stacked on #309 (FDv2 source-layer translation); that lands first.

## What this adds

The FDv2 orchestrator: the loop that runs the initializer chain to bring the SDK to a usable state, then drives the synchronizer tier with fallback and recovery transitions. Nothing constructs it in production yet (the data system wires it up in a later PR), so behavior is unchanged.

### The orchestration model

The orchestrator is subscription-driven rather than future-racing. Each synchronizer run holds exactly two subscriptions — one on the synchronizer's results, one on the merged condition stream — and a single outcome completer decides what happens next: advance to the next synchronizer (fallback fired or terminal error), recycle the current one (goodbye / invalid data), recover to the primary (recovery fired), or stop (shutdown). Everything a run allocates is subscription-scoped and released in its `finally`, so a healthy synchronizer that streams change sets indefinitely holds constant memory: there is no per-result allocation, and no listener is ever attached to a long-lived future (future listeners are only released on completion, which is the leak class this design avoids).

Other behaviors:

- Initializer results seed the selector; the first applied payload's selector is carried across source instances so reconnects resume with deltas.
- A server FDv1-fallback directive engages the FDv1 fallback tier when one is configured (the FDv1 slots start blocked).
- Exhausting every source without ever receiving data halts the data system with a shutdown status, so a pending identify fails rather than hanging; exhaustion after data was received logs and stops quietly.
- A configurable recycle delay separates goodbye-driven reconnects so a flapping server cannot drive a tight reconnect loop.

### `PayloadEvent`

Applied payloads are emitted as `PayloadEvent`s on the data source event stream — the already-parsed updates, rather than the FDv1 JSON string forms. Since `DataSourceEvent` is sealed, the FDv1 consumers (`DataSourceManager`, the polling and streaming data sources) gain no-op cases; FDv1 sources never produce payload events, and routing `PayloadEvent` into the event handler is the data system PR's job.

## Testing

Orchestrator tests drive full lifecycles with fake synchronizers and `fake_async`: initializer chain ordering and seeding, fallback after the interrupted timeout, recovery back to the primary, goodbye recycling with the delay, FDv1 fallback engagement, halt-on-exhaustion before first data, shutdown, and a memory-bound test asserting a healthy synchronizer streaming results holds constant memory across thousands of results. Full package suite passes.

SDK-2186

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core flag acquisition orchestration and identify/shutdown semantics, but production behavior is unchanged until the orchestrator is wired in.
> 
> **Overview**
> Adds the **FDv2 data source orchestrator** (`FDv2DataSourceOrchestrator`), which implements `DataSource` but is not wired into production yet. It runs the initializer chain until the SDK has basis data, then drives synchronizer tiers with **fallback**, **recovery**, **goodbye/restart recycling**, and optional **FDv1 fallback** engagement.
> 
> Applied FDv2 change sets are surfaced as a new sealed event type **`PayloadEvent`** (typed `ChangeSet`, not FDv1 JSON). FDv1 paths (`DataSourceManager`, polling, streaming) add **no-op** `PayloadEvent` branches so exhaustive switches compile; routing payloads into flag handling is left for a follow-up PR.
> 
> The orchestrator uses **subscription-driven** synchronizer runs (fixed listeners + outcome completer) to avoid per-result memory growth, reports recoverable errors via `DataSourceStatusManager`, and emits **shutdown** `StatusEvent`s only when sources exhaust or fail before any data (so identify does not hang). Extensive orchestrator tests cover lifecycles, halt/recovery edge cases, and a memory soak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63851e10d193b1f98ded84c7dea2d6eb0f00fae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->