### PR TITLE
feat: Translate FDv2 payloads at the data source layer

### DIFF
--- a/packages/common_client/lib/src/data_sources/data_source_event_handler.dart
+++ b/packages/common_client/lib/src/data_sources/data_source_event_handler.dart
@@ -102,11 +102,6 @@ final class DataSourceEventHandler {
   /// Full change sets replace the stored flags, partial change sets apply
   /// each update, and a change set of type none confirms the SDK is up to
   /// date without changing data. All three mark the data source valid.
-  ///
-  /// The change set is already translated into typed descriptors by the
-  /// data source layer, so malformed flag data never reaches here -- it is
-  /// surfaced as a data source error at acquisition time. The catch is a
-  /// backstop for an unexpected store/persistence failure.
   Future<MessageStatus> handlePayload(LDContext context, ChangeSet changeSet,
       {String? environmentId}) async {
     try {

--- a/packages/common_client/lib/src/data_sources/data_source_event_handler.dart
+++ b/packages/common_client/lib/src/data_sources/data_source_event_handler.dart
@@ -6,7 +6,6 @@ import '../flag_manager/flag_manager.dart';
 import '../item_descriptor.dart';
 import 'data_source_status.dart';
 import 'data_source_status_manager.dart';
-import 'fdv2/flag_eval_mapper.dart';
 import 'fdv2/payload.dart';
 
 enum MessageStatus { messageHandled, invalidMessage, unhandledVerb }
@@ -98,24 +97,28 @@ final class DataSourceEventHandler {
     }
   }
 
-  /// Applies an FDv2 payload to the flag store.
+  /// Applies an FDv2 change set to the flag store.
   ///
-  /// Full payloads replace the stored flags, partial payloads apply each
-  /// update, and a payload of type none confirms the SDK is up to date
-  /// without changing data. All three mark the data source valid.
-  Future<MessageStatus> handlePayload(LDContext context, Payload payload,
+  /// Full change sets replace the stored flags, partial change sets apply
+  /// each update, and a change set of type none confirms the SDK is up to
+  /// date without changing data. All three mark the data source valid.
+  ///
+  /// The change set is already translated into typed descriptors by the
+  /// data source layer, so malformed flag data never reaches here -- it is
+  /// surfaced as a data source error at acquisition time. The catch is a
+  /// backstop for an unexpected store/persistence failure.
+  Future<MessageStatus> handlePayload(LDContext context, ChangeSet changeSet,
       {String? environmentId}) async {
     try {
-      final updates = mapUpdatesToItemDescriptors(payload.updates);
-      await _flagManager.applyChanges(context, updates, payload.type,
+      await _flagManager.applyChanges(
+          context, changeSet.updates, changeSet.type,
           environmentId: environmentId);
       _statusManager.setValid();
       return MessageStatus.messageHandled;
     } catch (err) {
-      _logger.error('FDv2 payload contained invalid flag data: '
-          '${err.runtimeType}');
+      _logger.error('Failed to apply an FDv2 change set: ${err.runtimeType}');
       _statusManager.setErrorByKind(
-          ErrorKind.invalidData, 'FDv2 payload contained invalid data');
+          ErrorKind.invalidData, 'Failed to apply an FDv2 change set');
       return MessageStatus.invalidMessage;
     }
   }

--- a/packages/common_client/lib/src/data_sources/fdv2/cache_initializer.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/cache_initializer.dart
@@ -66,9 +66,6 @@ final class CacheInitializer implements Initializer {
       return _miss();
     }
 
-    // Cached flags are already typed evaluation results, so build the
-    // change set directly rather than round-tripping through the wire
-    // representation and back.
     final updates = <String, ItemDescriptor>{};
     cached.flags.forEach((key, evalResult) {
       updates[key] =

--- a/packages/common_client/lib/src/data_sources/fdv2/cache_initializer.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/cache_initializer.dart
@@ -1,8 +1,7 @@
 import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart';
 
-import 'flag_eval_mapper.dart';
+import '../../item_descriptor.dart';
 import 'payload.dart';
-import 'selector.dart';
 import 'source.dart';
 import 'source_result.dart';
 
@@ -67,20 +66,18 @@ final class CacheInitializer implements Initializer {
       return _miss();
     }
 
-    final updates = <Update>[];
+    // Cached flags are already typed evaluation results, so build the
+    // change set directly rather than round-tripping through the wire
+    // representation and back.
+    final updates = <String, ItemDescriptor>{};
     cached.flags.forEach((key, evalResult) {
-      updates.add(Update(
-        kind: flagEvalKind,
-        key: key,
-        version: evalResult.version,
-        object: LDEvaluationResultSerialization.toJson(evalResult),
-      ));
+      updates[key] =
+          ItemDescriptor(version: evalResult.version, flag: evalResult);
     });
 
     return ChangeSetResult(
-      payload: Payload(
+      changeSet: ChangeSet(
         type: PayloadType.full,
-        selector: Selector.empty,
         updates: updates,
       ),
       environmentId: cached.environmentId,
@@ -95,9 +92,9 @@ final class CacheInitializer implements Initializer {
   }
 
   ChangeSetResult _miss() => ChangeSetResult(
-        payload: const Payload(
+        changeSet: const ChangeSet(
           type: PayloadType.none,
-          updates: [],
+          updates: {},
         ),
         freshness: _now(),
         persist: false,

--- a/packages/common_client/lib/src/data_sources/fdv2/endpoints.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/endpoints.dart
@@ -1,3 +1,7 @@
+import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart';
+
+import 'selector.dart';
+
 /// FDv2 endpoint paths.
 ///
 /// These paths are uniform across mobile and browser SDKs; FDv2 does
@@ -19,4 +23,40 @@ abstract final class FDv2Endpoints {
   /// embedded in the URL path.
   static String streamingGet(String encodedContext) =>
       '$streaming/$encodedContext';
+}
+
+/// Builds an FDv2 request URI: appends [addedPath] to [baseUri]'s path and
+/// merges the [withReasons], [basis], and [additionalQueryParameters]
+/// query parameters onto the base URL's own.
+///
+/// Composes against the parsed [baseUri] so a custom URL carrying its own
+/// query parameters (e.g. a relay proxy with a token) is preserved --
+/// including repeated keys, via `queryParametersAll`, which a plain
+/// `queryParameters` map would collapse to the last value. String
+/// concatenation against the base would instead land the appended path
+/// inside the query component.
+///
+/// Shared by the polling requestor and the streaming source so the two
+/// transports build URLs identically.
+Uri buildFDv2Uri({
+  required Uri baseUri,
+  required String addedPath,
+  required bool withReasons,
+  required Selector basis,
+  Map<String, String> additionalQueryParameters = const {},
+}) {
+  final mergedPath = appendPath(baseUri.path, addedPath);
+  final mergedQuery = <String, dynamic>{}
+    ..addAll(baseUri.queryParametersAll)
+    ..addAll(additionalQueryParameters);
+  if (withReasons) {
+    mergedQuery['withReasons'] = 'true';
+  }
+  if (basis.state case final state? when state.isNotEmpty) {
+    mergedQuery['basis'] = state;
+  }
+  return baseUri.replace(
+    path: mergedPath,
+    queryParameters: mergedQuery.isEmpty ? null : mergedQuery,
+  );
 }

--- a/packages/common_client/lib/src/data_sources/fdv2/entry_factories.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/entry_factories.dart
@@ -2,9 +2,14 @@ import 'dart:convert';
 
 import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart'
     hide ServiceEndpoints;
+import 'package:launchdarkly_event_source_client/launchdarkly_event_source_client.dart';
 
+import '../../config/defaults/default_config.dart';
 import '../../config/service_endpoints.dart';
+import '../streaming_data_source.dart' show LDLoggerToEventSourceAdapter;
 import 'cache_initializer.dart' as cache_src;
+import 'endpoints.dart';
+import 'protocol_types.dart';
 import 'source_factory_context.dart';
 import 'mode_definition.dart' as mode;
 import 'polling_base.dart';
@@ -13,6 +18,8 @@ import 'polling_synchronizer.dart';
 import 'requestor.dart';
 import 'selector.dart';
 import 'source.dart';
+import 'streaming_base.dart';
+import 'streaming_synchronizer.dart';
 
 /// Merges per-entry [mode.EndpointConfig] overrides into [base].
 ServiceEndpoints mergeServiceEndpoints(
@@ -50,6 +57,7 @@ FDv2PollingBase _buildPollingBase({
     contextJson: ctx.contextJson,
     usePost: usePost,
     withReasons: ctx.withReasons,
+    additionalQueryParameters: ctx.additionalQueryParameters,
     httpProperties: ctx.httpProperties,
     httpClientFactory: ctx.httpClientFactory ?? _defaultHttpClientFactory,
   );
@@ -61,6 +69,69 @@ FDv2PollingBase _buildPollingBase({
 
 HttpClient _defaultHttpClientFactory(HttpProperties httpProperties) {
   return HttpClient(httpProperties: httpProperties);
+}
+
+/// Constructs the [SSEClient] used by a streaming source. [uriProvider]
+/// is re-invoked on every connection attempt so the `basis` query
+/// parameter reflects the current selector. Tests inject a fake.
+typedef FDv2SseClientFactory = SSEClient Function({
+  required Uri Function() uriProvider,
+  required HttpProperties httpProperties,
+  required String? body,
+  required SseHttpMethod method,
+  required EventSourceLogger logger,
+});
+
+/// FDv2 event names subscribed on the streaming connection. Includes the
+/// legacy `ping` bridge event.
+const Set<String> _fdv2StreamEventNames = {
+  FDv2EventTypes.serverIntent,
+  FDv2EventTypes.putObject,
+  FDv2EventTypes.deleteObject,
+  FDv2EventTypes.payloadTransferred,
+  FDv2EventTypes.goodbye,
+  FDv2EventTypes.error,
+  FDv2EventTypes.heartbeat,
+  'ping',
+};
+
+/// Constructs the production [SSEClient]. The default for the factory
+/// builders; tests inject a fake through the same parameter.
+SSEClient defaultSseClientFactory({
+  required Uri Function() uriProvider,
+  required HttpProperties httpProperties,
+  required String? body,
+  required SseHttpMethod method,
+  required EventSourceLogger logger,
+}) {
+  return SSEClient(uriProvider(), _fdv2StreamEventNames,
+      headers: httpProperties.baseHeaders,
+      body: body,
+      httpMethod: method,
+      logger: logger,
+      uriProvider: uriProvider);
+}
+
+/// Builds the streaming URI for the current state. Invoked per
+/// connection attempt so the `basis` parameter tracks the selector.
+Uri _buildStreamingUri({
+  required ServiceEndpoints endpoints,
+  required String contextEncoded,
+  required bool usePost,
+  required bool withReasons,
+  required Selector basis,
+  Map<String, String> additionalQueryParameters = const {},
+}) {
+  final addedPath = usePost
+      ? FDv2Endpoints.streaming
+      : FDv2Endpoints.streamingGet(contextEncoded);
+  return buildFDv2Uri(
+    baseUri: Uri.parse(endpoints.streaming),
+    addedPath: addedPath,
+    withReasons: withReasons,
+    basis: basis,
+    additionalQueryParameters: additionalQueryParameters,
+  );
 }
 
 /// A factory for creating [Initializer] instances.
@@ -130,12 +201,11 @@ InitializerFactory createInitializerFactoryFromEntry(
 }
 
 /// Builds a [SynchronizerFactory] for a single [mode.SynchronizerEntry].
-///
-/// Throws [UnsupportedError] for unsupported entry types.
 SynchronizerFactory createSynchronizerFactoryFromEntry(
   mode.SynchronizerEntry entry,
-  SourceFactoryContext ctx,
-) {
+  SourceFactoryContext ctx, {
+  FDv2SseClientFactory sseClientFactory = defaultSseClientFactory,
+}) {
   switch (entry) {
     case final mode.PollingSynchronizer e:
       final interval = e.pollInterval ?? ctx.defaultPollingInterval;
@@ -155,9 +225,47 @@ SynchronizerFactory createSynchronizerFactoryFromEntry(
           );
         },
       );
-    case mode.StreamingSynchronizer():
-      throw UnsupportedError(
-        'FDv2 StreamingSynchronizer factories are not implemented yet',
+    case final mode.StreamingSynchronizer e:
+      return SynchronizerFactory(
+        create: (SelectorGetter selectorGetter) {
+          final endpointsResolved =
+              mergeServiceEndpoints(ctx.serviceEndpoints, e.endpoints);
+          Uri uriProvider() => _buildStreamingUri(
+                endpoints: endpointsResolved,
+                contextEncoded: base64UrlEncode(utf8.encode(ctx.contextJson)),
+                usePost: e.usePost,
+                withReasons: ctx.withReasons,
+                basis: selectorGetter(),
+                additionalQueryParameters: ctx.additionalQueryParameters,
+              );
+          final sseClient = sseClientFactory(
+            uriProvider: uriProvider,
+            httpProperties: ctx.httpProperties,
+            body: e.usePost ? ctx.contextJson : null,
+            method: e.usePost ? SseHttpMethod.post : SseHttpMethod.get,
+            logger: LDLoggerToEventSourceAdapter(ctx.logger),
+          );
+
+          // Legacy ping events trigger a one-shot poll.
+          final pingPollingBase = _buildPollingBase(
+            endpoints: e.endpoints,
+            usePost: e.usePost,
+            ctx: ctx,
+          );
+
+          return FDv2StreamingSynchronizer(
+            base: FDv2StreamingBase(
+              sseClient: sseClient,
+              pingHandler: () =>
+                  pingPollingBase.pollOnce(basis: selectorGetter()),
+              logger: ctx.logger,
+              // Used when the transport exposes no response headers (the
+              // browser EventSource) to read x-ld-envid from.
+              defaultEnvironmentId: DefaultConfig.credentialConfig
+                  .environmentIdFallback(ctx.credential),
+            ),
+          );
+        },
       );
   }
 }
@@ -173,9 +281,11 @@ List<InitializerFactory> buildInitializerFactories(
 /// One factory per entry, in list order.
 List<SynchronizerFactory> buildSynchronizerFactories(
   List<mode.SynchronizerEntry> entries,
-  SourceFactoryContext ctx,
-) {
+  SourceFactoryContext ctx, {
+  FDv2SseClientFactory sseClientFactory = defaultSseClientFactory,
+}) {
   return entries
-      .map((e) => createSynchronizerFactoryFromEntry(e, ctx))
+      .map((e) => createSynchronizerFactoryFromEntry(e, ctx,
+          sseClientFactory: sseClientFactory))
       .toList();
 }

--- a/packages/common_client/lib/src/data_sources/fdv2/flag_eval_mapper.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/flag_eval_mapper.dart
@@ -9,10 +9,8 @@ const String flagEvalKind = 'flag-eval';
 /// Translates a wire-level [Payload] into a typed [ChangeSet] ready for
 /// the flag store.
 ///
-/// Throws if any flag-eval object cannot be parsed. The data source layer
-/// calls this at acquisition time and reports a failure as a data source
-/// error, so the connection recovers rather than the failure surfacing
-/// later at apply time.
+/// Throws if any flag-eval object cannot be parsed, so the data source
+/// layer can report it as a data source error and recover the connection.
 ChangeSet translatePayload(Payload payload) {
   return ChangeSet(
     selector: payload.selector,

--- a/packages/common_client/lib/src/data_sources/fdv2/flag_eval_mapper.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/flag_eval_mapper.dart
@@ -6,6 +6,21 @@ import 'payload.dart';
 /// The object kind for client-side flag evaluation results.
 const String flagEvalKind = 'flag-eval';
 
+/// Translates a wire-level [Payload] into a typed [ChangeSet] ready for
+/// the flag store.
+///
+/// Throws if any flag-eval object cannot be parsed. The data source layer
+/// calls this at acquisition time and reports a failure as a data source
+/// error, so the connection recovers rather than the failure surfacing
+/// later at apply time.
+ChangeSet translatePayload(Payload payload) {
+  return ChangeSet(
+    selector: payload.selector,
+    type: payload.type,
+    updates: mapUpdatesToItemDescriptors(payload.updates),
+  );
+}
+
 /// Converts FDv2 [Update] objects to a map of [ItemDescriptor]s suitable
 /// for the flag store.
 ///

--- a/packages/common_client/lib/src/data_sources/fdv2/payload.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/payload.dart
@@ -1,5 +1,6 @@
 import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart';
 
+import '../../item_descriptor.dart';
 import 'selector.dart';
 
 /// The type of payload transfer.
@@ -93,5 +94,38 @@ final class Payload {
 
   @override
   String toString() => 'Payload(selector: $selector, type: $type, '
+      'updates: ${updates.length})';
+}
+
+/// A [Payload] translated into typed flag descriptors, ready to apply to
+/// the flag store.
+///
+/// The wire-level [Payload] carries raw [Update] objects; producing a
+/// [ChangeSet] converts each flag-eval object into an [ItemDescriptor].
+/// That conversion is performed by the data source layer (see
+/// `translatePayload`) so a malformed object is reported as a data source
+/// error at acquisition time -- where the connection can recover -- rather
+/// than surfacing later, at apply time.
+final class ChangeSet {
+  /// The selector for this change set, carried over from the originating
+  /// [Payload]. [Selector.empty] when the source provided none (cached
+  /// data or an intent of none).
+  final Selector selector;
+
+  /// Whether this is a full, partial, or no-op change set.
+  final PayloadType type;
+
+  /// The typed updates, keyed by flag key. A tombstone (deletion) is an
+  /// [ItemDescriptor] with a null flag.
+  final Map<String, ItemDescriptor> updates;
+
+  const ChangeSet({
+    this.selector = Selector.empty,
+    required this.type,
+    required this.updates,
+  });
+
+  @override
+  String toString() => 'ChangeSet(selector: $selector, type: $type, '
       'updates: ${updates.length})';
 }

--- a/packages/common_client/lib/src/data_sources/fdv2/payload.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/payload.dart
@@ -102,10 +102,9 @@ final class Payload {
 ///
 /// The wire-level [Payload] carries raw [Update] objects; producing a
 /// [ChangeSet] converts each flag-eval object into an [ItemDescriptor].
-/// That conversion is performed by the data source layer (see
-/// `translatePayload`) so a malformed object is reported as a data source
-/// error at acquisition time -- where the connection can recover -- rather
-/// than surfacing later, at apply time.
+/// The data source layer performs this conversion (see `translatePayload`),
+/// so a malformed object is reported as a data source error where the
+/// connection can recover.
 final class ChangeSet {
   /// The selector for this change set, carried over from the originating
   /// [Payload]. [Selector.empty] when the source provided none (cached

--- a/packages/common_client/lib/src/data_sources/fdv2/polling_base.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/polling_base.dart
@@ -73,7 +73,7 @@ final class FDv2PollingBase {
     // 304 Not Modified means the SDK's cached data is confirmed current.
     if (response.status == 304) {
       return ChangeSetResult(
-        payload: const Payload(type: PayloadType.none, updates: []),
+        changeSet: const ChangeSet(type: PayloadType.none, updates: {}),
         environmentId: environmentId,
         freshness: _now(),
         persist: true,
@@ -135,8 +135,12 @@ final class FDv2PollingBase {
         final action = handler.processEvent(event);
         switch (action) {
           case ActionPayload(:final payload):
+            // translatePayload may throw on a flag-eval object that
+            // cannot be parsed; the surrounding catch converts that into
+            // an interrupted result, the same as a malformed protocol
+            // body.
             return ChangeSetResult(
-              payload: payload,
+              changeSet: translatePayload(payload),
               environmentId: environmentId,
               freshness: _now(),
               persist: true,

--- a/packages/common_client/lib/src/data_sources/fdv2/requestor.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/requestor.dart
@@ -1,5 +1,7 @@
-import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart';
+import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart'
+    hide ServiceEndpoints;
 
+import '../../config/service_endpoints.dart';
 import 'endpoints.dart';
 import 'selector.dart';
 
@@ -39,6 +41,7 @@ final class FDv2Requestor {
   final String _contextJson;
   final bool _usePost;
   final bool _withReasons;
+  final Map<String, String> _additionalQueryParameters;
   String? _lastEtag;
 
   FDv2Requestor({
@@ -49,6 +52,7 @@ final class FDv2Requestor {
     required bool usePost,
     required bool withReasons,
     required HttpProperties httpProperties,
+    Map<String, String> additionalQueryParameters = const {},
     HttpClientFactory httpClientFactory = _defaultHttpClientFactory,
   })  : _logger = logger.subLogger('FDv2Requestor'),
         _baseUri = Uri.parse(endpoints.polling),
@@ -56,6 +60,7 @@ final class FDv2Requestor {
         _contextJson = contextJson,
         _usePost = usePost,
         _withReasons = withReasons,
+        _additionalQueryParameters = additionalQueryParameters,
         _client = httpClientFactory(usePost
             ? httpProperties.withHeaders({'content-type': 'application/json'})
             : httpProperties);
@@ -111,30 +116,12 @@ final class FDv2Requestor {
     final addedPath = _usePost
         ? FDv2Endpoints.polling
         : FDv2Endpoints.pollingGet(_contextEncoded);
-
-    // Compose against the parsed base URI so a custom polling URL
-    // carrying its own query parameters (e.g. a relay proxy with a token)
-    // is preserved correctly. String concatenation against `_baseUri`
-    // would land the appended path inside the query component.
-    final basePath = _baseUri.path.endsWith('/')
-        ? _baseUri.path.substring(0, _baseUri.path.length - 1)
-        : _baseUri.path;
-    final mergedPath = '$basePath$addedPath';
-
-    // Use queryParametersAll so a base URL like `?dup=1&dup=2` round-trips
-    // both values; the simpler `queryParameters` map collapses duplicates.
-    final mergedQuery = <String, dynamic>{};
-    mergedQuery.addAll(_baseUri.queryParametersAll);
-    if (_withReasons) {
-      mergedQuery['withReasons'] = 'true';
-    }
-    if (basis.state case final state? when state.isNotEmpty) {
-      mergedQuery['basis'] = state;
-    }
-
-    return _baseUri.replace(
-      path: mergedPath,
-      queryParameters: mergedQuery.isEmpty ? null : mergedQuery,
+    return buildFDv2Uri(
+      baseUri: _baseUri,
+      addedPath: addedPath,
+      withReasons: _withReasons,
+      basis: basis,
+      additionalQueryParameters: _additionalQueryParameters,
     );
   }
 }

--- a/packages/common_client/lib/src/data_sources/fdv2/source_factory_context.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/source_factory_context.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart'
     hide ServiceEndpoints;
 
+import '../../config/defaults/default_config.dart';
 import '../../config/service_endpoints.dart';
 import 'cache_initializer.dart';
 import 'requestor.dart';
@@ -29,6 +30,14 @@ final class SourceFactoryContext {
 
   final HttpClientFactory? httpClientFactory;
 
+  /// The SDK credential. Used as the environment identifier when the
+  /// platform's credential is a client-side ID.
+  final String credential;
+
+  /// Additional query parameters applied to every data acquisition
+  /// request, both polling and streaming.
+  final Map<String, String> additionalQueryParameters;
+
   const SourceFactoryContext({
     required this.context,
     required this.logger,
@@ -38,6 +47,8 @@ final class SourceFactoryContext {
     required this.withReasons,
     required this.defaultPollingInterval,
     required this.cachedFlagsReader,
+    required this.credential,
+    this.additionalQueryParameters = const {},
     this.httpClientFactory,
   });
 
@@ -49,6 +60,7 @@ final class SourceFactoryContext {
     required bool withReasons,
     required Duration defaultPollingInterval,
     required CachedFlagsReader cachedFlagsReader,
+    required String credential,
     HttpClientFactory? httpClientFactory,
   }) {
     final plainContextString =
@@ -62,6 +74,13 @@ final class SourceFactoryContext {
       withReasons: withReasons,
       defaultPollingInterval: defaultPollingInterval,
       cachedFlagsReader: cachedFlagsReader,
+      credential: credential,
+      // Platforms that authenticate with the `auth` query parameter
+      // (browsers) supply it here; platforms that authenticate with the
+      // authorization header in the base headers (mobile keys) supply
+      // nothing.
+      additionalQueryParameters:
+          DefaultConfig.credentialConfig.authQueryParameters(credential),
       httpClientFactory: httpClientFactory,
     );
   }

--- a/packages/common_client/lib/src/data_sources/fdv2/source_result.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/source_result.dart
@@ -23,10 +23,10 @@ sealed class FDv2SourceResult {
   const FDv2SourceResult({this.fdv1Fallback = false});
 }
 
-/// A data payload was received.
+/// A data payload was received and translated into typed descriptors.
 final class ChangeSetResult extends FDv2SourceResult {
-  /// The payload containing updates.
-  final Payload payload;
+  /// The translated change set ready to apply to the flag store.
+  final ChangeSet changeSet;
 
   /// The environment ID from response headers, if present.
   final String? environmentId;
@@ -38,7 +38,7 @@ final class ChangeSetResult extends FDv2SourceResult {
   final bool persist;
 
   const ChangeSetResult({
-    required this.payload,
+    required this.changeSet,
     required this.persist,
     this.environmentId,
     this.freshness,
@@ -46,9 +46,9 @@ final class ChangeSetResult extends FDv2SourceResult {
   });
 
   @override
-  String toString() => 'ChangeSetResult(type: ${payload.type}, '
-      'updates: ${payload.updates.length}, '
-      'hasSelector: ${payload.selector.isNotEmpty}, '
+  String toString() => 'ChangeSetResult(type: ${changeSet.type}, '
+      'updates: ${changeSet.updates.length}, '
+      'hasSelector: ${changeSet.selector.isNotEmpty}, '
       'persist: $persist, fdv1Fallback: $fdv1Fallback)';
 }
 
@@ -82,14 +82,14 @@ final class StatusResult extends FDv2SourceResult {
 /// Factory functions for creating common result types.
 abstract final class FDv2SourceResults {
   static ChangeSetResult changeSet({
-    required Payload payload,
+    required ChangeSet changeSet,
     required bool persist,
     String? environmentId,
     DateTime? freshness,
     bool fdv1Fallback = false,
   }) =>
       ChangeSetResult(
-        payload: payload,
+        changeSet: changeSet,
         persist: persist,
         environmentId: environmentId,
         freshness: freshness,

--- a/packages/common_client/lib/src/data_sources/fdv2/streaming_base.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/streaming_base.dart
@@ -6,6 +6,7 @@ import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart';
 import 'package:launchdarkly_event_source_client/launchdarkly_event_source_client.dart';
 
 import 'flag_eval_mapper.dart';
+import 'payload.dart';
 import 'protocol_handler.dart';
 import 'protocol_types.dart';
 import 'source.dart';
@@ -18,7 +19,10 @@ import 'source_result.dart';
 /// fresh [FDv2ProtocolHandler]. The first emitted [ProtocolAction]
 /// per event is translated into an [FDv2SourceResult]:
 ///
-/// - [ActionPayload] --> [ChangeSetResult] with `persist: true`.
+/// - [ActionPayload] --> translated into a [ChangeSet] and emitted as a
+///   [ChangeSetResult] with `persist: true`. A payload whose flag-eval
+///   objects cannot be parsed is surfaced as an interrupted
+///   [StatusResult] instead, the same as any other transient data error.
 /// - [ActionGoodbye] --> goodbye [StatusResult]; the SSE connection is
 ///   closed.
 /// - [ActionServerError] / [ActionError] --> interrupted
@@ -226,8 +230,25 @@ final class FDv2StreamingBase {
 
     switch (action) {
       case ActionPayload(:final payload):
+        final ChangeSet changeSet;
+        try {
+          changeSet = translatePayload(payload);
+        } catch (err) {
+          // A protocol-valid payload whose flag-eval objects cannot be
+          // parsed. Treat it like any other transient data error:
+          // discard the partial state and surface interrupted, which
+          // arms the orchestrator's fallback timer. The SSE connection
+          // stays up and the server's next payload is processed by the
+          // fresh handler.
+          _logger.warn(
+              'Streaming payload contained invalid flag data (${err.runtimeType})');
+          _resetHandler();
+          _emit(FDv2SourceResults.interrupted(
+              message: 'Streaming payload contained invalid flag data'));
+          return;
+        }
         _emit(ChangeSetResult(
-          payload: payload,
+          changeSet: changeSet,
           environmentId: _environmentId,
           freshness: freshness,
           persist: true,

--- a/packages/common_client/lib/src/data_sources/fdv2/streaming_base.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/streaming_base.dart
@@ -65,9 +65,11 @@ final class FDv2StreamingBase {
     required SSEClient sseClient,
     required PingHandler pingHandler,
     required LDLogger logger,
+    String? defaultEnvironmentId,
     DateTime Function()? now,
   })  : _sseClient = sseClient,
         _pingHandler = pingHandler,
+        _environmentId = defaultEnvironmentId,
         _logger = logger.subLogger('FDv2StreamingBase'),
         _now = now ?? DateTime.now {
     _controller = StreamController<FDv2SourceResult>(
@@ -314,6 +316,24 @@ final class FDv2StreamingBase {
 
   void _handleSseError(Object err, StackTrace stack) {
     if (_stoppedSignal.isCompleted) return;
+
+    if (err is UnrecoverableStatusError) {
+      // The SSE client stops reconnecting for these status codes, so the
+      // source cannot recover on its own. Surface a terminal error so the
+      // orchestrator moves to another source. The error response may also
+      // carry the FDv1 fallback directive.
+      final fallback = err.headers['x-ld-fd-fallback']?.toLowerCase() == 'true';
+      _logger.warn(
+          'Streaming request failed with status ${err.statusCode}; giving up');
+      _terminate(
+          finalResult: FDv2SourceResults.terminalError(
+        message: 'Streaming request failed with status ${err.statusCode}',
+        statusCode: err.statusCode,
+        fdv1Fallback: fallback,
+      ));
+      return;
+    }
+
     // The SSE client's built-in backoff handles reconnection. Surface
     // the disruption as interrupted; the orchestrator decides whether
     // to fall through to a different source after enough time.

--- a/packages/common_client/test/data_sources/data_source_event_handler_test.dart
+++ b/packages/common_client/test/data_sources/data_source_event_handler_test.dart
@@ -4,6 +4,8 @@ import 'package:launchdarkly_common_client/src/data_sources/data_source_status.d
 import 'package:launchdarkly_common_client/src/data_sources/data_source_status_manager.dart';
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/payload.dart';
 import 'package:launchdarkly_common_client/src/flag_manager/flag_manager.dart';
+import 'package:launchdarkly_common_client/src/item_descriptor.dart';
+import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -287,33 +289,35 @@ void main() {
     });
 
     group('handlePayload', () {
-      Update flagEval(String key, int version, {Object? value = true}) =>
-          Update(
-            kind: 'flag-eval',
-            key: key,
+      // The change set reaching handlePayload is already translated into
+      // typed descriptors by the data source layer, so these build
+      // descriptors directly. Translation-failure handling is covered at
+      // the source layer (streaming/polling base tests).
+      ItemDescriptor flagEval(int version, {bool value = true}) =>
+          ItemDescriptor(
             version: version,
-            object: {
-              'flagVersion': 5,
-              'value': value,
-              'variation': 0,
-              'trackEvents': false,
-            },
+            flag: LDEvaluationResult(
+              version: version,
+              detail: LDEvaluationDetail(
+                  LDValue.ofBool(value), 0, LDEvaluationReason.off()),
+            ),
           );
 
-      test('a full payload replaces the stored flags and sets valid', () async {
+      test('a full change set replaces the stored flags and sets valid',
+          () async {
         expectLater(
             statusManager!.changes,
             emits(DataSourceStatus(
                 state: DataSourceState.valid, stateSince: DateTime(2))));
 
         await eventHandler!.handlePayload(context,
-            Payload(type: PayloadType.full, updates: [flagEval('flagA', 1)]));
+            ChangeSet(type: PayloadType.full, updates: {'flagA': flagEval(1)}));
 
         expect(
             await eventHandler!.handlePayload(
                 context,
-                Payload(
-                    type: PayloadType.full, updates: [flagEval('flagB', 2)]),
+                ChangeSet(
+                    type: PayloadType.full, updates: {'flagB': flagEval(2)}),
                 environmentId: 'the-environment-id'),
             MessageStatus.messageHandled);
 
@@ -324,17 +328,17 @@ void main() {
       });
 
       test(
-          'a partial payload applies updates without per-item version '
+          'a partial change set applies updates without per-item version '
           'comparison and sets valid', () async {
         await eventHandler!.handlePayload(context,
-            Payload(type: PayloadType.full, updates: [flagEval('flagA', 7)]));
+            ChangeSet(type: PayloadType.full, updates: {'flagA': flagEval(7)}));
 
         expect(
             await eventHandler!.handlePayload(
                 context,
-                Payload(
+                ChangeSet(
                     type: PayloadType.partial,
-                    updates: [flagEval('flagA', 3, value: false)])),
+                    updates: {'flagA': flagEval(3, value: false)})),
             MessageStatus.messageHandled);
 
         final updated = flagManager!.get('flagA')!.flag!;
@@ -344,41 +348,16 @@ void main() {
         expect(updated.detail.value, LDValue.ofBool(false));
       });
 
-      test('a payload of none changes no data and sets valid', () async {
+      test('a change set of none changes no data and sets valid', () async {
         await eventHandler!.handlePayload(context,
-            Payload(type: PayloadType.full, updates: [flagEval('flagA', 1)]));
+            ChangeSet(type: PayloadType.full, updates: {'flagA': flagEval(1)}));
 
         expect(
             await eventHandler!.handlePayload(
-                context, const Payload(type: PayloadType.none, updates: [])),
+                context, const ChangeSet(type: PayloadType.none, updates: {})),
             MessageStatus.messageHandled);
 
         expect(flagManager!.get('flagA')?.flag?.version, 1);
-      });
-
-      test('invalid flag data sets an invalid data error', () async {
-        expectLater(
-            statusManager!.changes,
-            emits(DataSourceStatus(
-                lastError: DataSourceStatusErrorInfo(
-                    kind: ErrorKind.invalidData,
-                    message: 'FDv2 payload contained invalid data',
-                    statusCode: null,
-                    time: DateTime(2)),
-                state: DataSourceState.initializing,
-                stateSince: DateTime(1))));
-
-        expect(
-            await eventHandler!.handlePayload(
-                context,
-                Payload(type: PayloadType.full, updates: [
-                  const Update(
-                      kind: 'flag-eval',
-                      key: 'bad',
-                      version: 1,
-                      object: {'trackEvents': 'not-a-bool'})
-                ])),
-            MessageStatus.invalidMessage);
       });
     });
   });

--- a/packages/common_client/test/data_sources/fdv2/cache_initializer_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/cache_initializer_test.dart
@@ -42,23 +42,22 @@ void main() {
     expect(result, isA<ChangeSetResult>());
     final cs = result as ChangeSetResult;
     expect(cs.persist, isFalse);
-    expect(cs.payload.type, equals(PayloadType.full));
-    expect(cs.payload.selector.isEmpty, isTrue);
+    expect(cs.changeSet.type, equals(PayloadType.full));
+    expect(cs.changeSet.selector.isEmpty, isTrue);
     expect(cs.environmentId, equals('env-xyz'));
-    expect(cs.payload.updates, hasLength(2));
+    expect(cs.changeSet.updates, hasLength(2));
 
-    final byKey = {for (final u in cs.payload.updates) u.key: u};
-    expect(byKey['flag-a']?.version, equals(7));
-    expect(byKey['flag-a']?.kind, equals('flag-eval'));
-    expect(byKey['flag-a']?.deleted, isFalse);
-    expect(byKey['flag-a']?.object, isNotNull);
-    expect(byKey['flag-b']?.version, equals(9));
+    final updates = cs.changeSet.updates;
+    expect(updates['flag-a']?.version, equals(7));
+    expect(updates['flag-a']?.flag, isNotNull);
+    expect(updates['flag-b']?.version, equals(9));
   });
 
-  test('cache hit Updates round-trip through LDEvaluationResultSerialization',
+  test('cache hit carries the evaluation result through without re-parsing',
       () async {
-    // Confirms the cache initializer writes the same JSON shape that the
-    // protocol handler's flag_eval mapper expects on the read side.
+    // Cached flags are already typed; the initializer places the
+    // evaluation result directly in the descriptor rather than
+    // round-tripping it through the wire JSON shape.
     final original = _evalResult(version: 42);
     final init = CacheInitializer(
       reader: _staticReader((flags: {'k': original}, environmentId: null)),
@@ -68,11 +67,10 @@ void main() {
 
     final result = await init.run();
     final cs = result as ChangeSetResult;
-    final update = cs.payload.updates.single;
+    final descriptor = cs.changeSet.updates['k']!;
 
-    final reconstructed =
-        LDEvaluationResultSerialization.fromJson(update.object!);
-    expect(reconstructed, equals(original));
+    expect(descriptor.version, equals(42));
+    expect(descriptor.flag, equals(original));
   });
 
   test('cache miss emits a none-type ChangeSetResult so the chain advances',
@@ -87,8 +85,8 @@ void main() {
 
     expect(result, isA<ChangeSetResult>());
     final cs = result as ChangeSetResult;
-    expect(cs.payload.type, equals(PayloadType.none));
-    expect(cs.payload.updates, isEmpty);
+    expect(cs.changeSet.type, equals(PayloadType.none));
+    expect(cs.changeSet.updates, isEmpty);
     expect(cs.persist, isFalse);
     expect(cs.environmentId, isNull);
   });
@@ -104,7 +102,8 @@ void main() {
     final result = await init.run();
 
     expect(result, isA<ChangeSetResult>());
-    expect((result as ChangeSetResult).payload.type, equals(PayloadType.none));
+    expect(
+        (result as ChangeSetResult).changeSet.type, equals(PayloadType.none));
   });
 
   test('close before run returns shutdown without invoking reader', () async {

--- a/packages/common_client/test/data_sources/fdv2/conditions_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/conditions_test.dart
@@ -5,7 +5,7 @@ import 'package:launchdarkly_common_client/src/data_sources/fdv2/source_result.d
 import 'package:test/test.dart';
 
 ChangeSetResult _changeSet() => const ChangeSetResult(
-      payload: Payload(type: PayloadType.full, updates: []),
+      changeSet: ChangeSet(type: PayloadType.full, updates: {}),
       persist: true,
     );
 

--- a/packages/common_client/test/data_sources/fdv2/entry_factories_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/entry_factories_test.dart
@@ -1,3 +1,5 @@
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:launchdarkly_common_client/src/config/service_endpoints.dart';
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/built_in_modes.dart';
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/cache_initializer.dart';
@@ -7,8 +9,10 @@ import 'package:launchdarkly_common_client/src/data_sources/fdv2/mode_definition
     hide CacheInitializer;
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/payload.dart';
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/polling_synchronizer.dart';
+import 'package:launchdarkly_common_client/src/data_sources/fdv2/streaming_synchronizer.dart';
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/selector.dart';
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/source_result.dart';
+import 'package:launchdarkly_event_source_client/launchdarkly_event_source_client.dart';
 import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart'
     hide ServiceEndpoints;
 import 'package:test/test.dart';
@@ -22,6 +26,7 @@ SourceFactoryContext _testContext({
   Duration? defaultPollingInterval,
 }) {
   return SourceFactoryContext.fromClientConfig(
+    credential: 'test-credential',
     context: _context(),
     logger: LDLogger(level: LDLogLevel.error),
     httpProperties: HttpProperties(),
@@ -113,12 +118,110 @@ void main() {
       sync.close();
     });
 
-    test('streaming synchronizer is unsupported', () {
+    test('builds factory whose create returns FDv2StreamingSynchronizer', () {
       final ctx = _testContext();
-      expect(
-        () => createSynchronizerFactoryFromEntry(StreamingSynchronizer(), ctx),
-        throwsA(isA<UnsupportedError>()),
+      final factory =
+          createSynchronizerFactoryFromEntry(StreamingSynchronizer(), ctx);
+      final sync = factory.create(_selectorGetter);
+      expect(sync, isA<FDv2StreamingSynchronizer>());
+      sync.close();
+    });
+
+    test(
+        'streaming URI carries the auth query parameters and the current '
+        'basis', () {
+      final ctx = SourceFactoryContext(
+        context: _context(),
+        credential: 'the-client-side-id',
+        additionalQueryParameters: const {'auth': 'the-client-side-id'},
+        logger: LDLogger(level: LDLogLevel.error),
+        httpProperties: HttpProperties(),
+        serviceEndpoints: ServiceEndpoints.custom(
+            polling: 'https://poll.test', streaming: 'https://stream.test'),
+        contextJson: '{"key":"test","kind":"user"}',
+        withReasons: false,
+        defaultPollingInterval: const Duration(seconds: 300),
+        cachedFlagsReader: (_) async => null,
       );
+
+      var selector = Selector.empty;
+      late Uri Function() capturedUriProvider;
+      final factory = createSynchronizerFactoryFromEntry(
+        StreamingSynchronizer(),
+        ctx,
+        sseClientFactory: ({
+          required Uri Function() uriProvider,
+          required HttpProperties httpProperties,
+          required String? body,
+          required SseHttpMethod method,
+          required EventSourceLogger logger,
+        }) {
+          capturedUriProvider = uriProvider;
+          return SSEClient.testClient(uriProvider(), const {});
+        },
+      );
+      final sync = factory.create(() => selector);
+
+      final initialUri = capturedUriProvider();
+      expect(initialUri.host, equals('stream.test'));
+      expect(initialUri.path, startsWith('/sdk/stream/eval/'));
+      expect(initialUri.queryParameters['auth'], equals('the-client-side-id'));
+      expect(initialUri.queryParameters.containsKey('basis'), isFalse);
+
+      selector = const Selector(state: '(p:abc:1)', version: 1);
+      final reconnectUri = capturedUriProvider();
+      expect(
+          reconnectUri.queryParameters['auth'], equals('the-client-side-id'));
+      expect(reconnectUri.queryParameters['basis'], equals('(p:abc:1)'));
+
+      sync.close();
+    });
+
+    test(
+        'streaming URI preserves repeated query keys on the base URL across '
+        'reconnects', () {
+      final ctx = SourceFactoryContext(
+        context: _context(),
+        credential: 'cid',
+        logger: LDLogger(level: LDLogLevel.error),
+        httpProperties: HttpProperties(),
+        serviceEndpoints: ServiceEndpoints.custom(
+            polling: 'https://poll.test',
+            streaming: 'https://relay.test/?tag=a&tag=b'),
+        contextJson: '{"key":"test","kind":"user"}',
+        withReasons: false,
+        defaultPollingInterval: const Duration(seconds: 300),
+        cachedFlagsReader: (_) async => null,
+      );
+
+      var selector = Selector.empty;
+      late Uri Function() capturedUriProvider;
+      final factory = createSynchronizerFactoryFromEntry(
+        StreamingSynchronizer(),
+        ctx,
+        sseClientFactory: ({
+          required Uri Function() uriProvider,
+          required HttpProperties httpProperties,
+          required String? body,
+          required SseHttpMethod method,
+          required EventSourceLogger logger,
+        }) {
+          capturedUriProvider = uriProvider;
+          return SSEClient.testClient(uriProvider(), const {});
+        },
+      );
+      final sync = factory.create(() => selector);
+
+      // A relay-style base URL with a repeated key must round-trip both
+      // values, matching the polling requestor -- and on every reconnect,
+      // since the provider rebuilds the URI each time.
+      expect(
+          capturedUriProvider().queryParametersAll['tag'], equals(['a', 'b']));
+      selector = const Selector(state: '(p:abc:1)', version: 1);
+      expect(
+          capturedUriProvider().queryParametersAll['tag'], equals(['a', 'b']));
+
+      sync.close();
     });
   });
 
@@ -129,6 +232,37 @@ void main() {
         () => createInitializerFactoryFromEntry(StreamingInitializer(), ctx),
         throwsA(isA<UnsupportedError>()),
       );
+    });
+
+    test('polling request carries the auth query parameters', () async {
+      late Uri capturedUri;
+      final mock = MockClient((request) async {
+        capturedUri = request.url;
+        return http.Response('{"events":[]}', 200);
+      });
+      final ctx = SourceFactoryContext(
+        context: _context(),
+        credential: 'the-client-side-id',
+        additionalQueryParameters: const {'auth': 'the-client-side-id'},
+        logger: LDLogger(level: LDLogLevel.error),
+        httpProperties: HttpProperties(),
+        serviceEndpoints:
+            ServiceEndpoints.custom(polling: 'https://example.test'),
+        contextJson: '{"key":"test","kind":"user"}',
+        withReasons: false,
+        defaultPollingInterval: const Duration(seconds: 300),
+        cachedFlagsReader: (_) async => null,
+        httpClientFactory: (props) =>
+            HttpClient(client: mock, httpProperties: props),
+      );
+
+      final factory =
+          createInitializerFactoryFromEntry(PollingInitializer(), ctx);
+      final init = factory.create(_selectorGetter);
+      await init.run();
+
+      expect(capturedUri.queryParameters,
+          containsPair('auth', 'the-client-side-id'));
     });
   });
 

--- a/packages/common_client/test/data_sources/fdv2/entry_factories_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/entry_factories_test.dart
@@ -144,6 +144,6 @@ void main() {
     final result = await init.run();
     expect(result, isA<ChangeSetResult>());
     final cs = result as ChangeSetResult;
-    expect(cs.payload.type, PayloadType.none);
+    expect(cs.changeSet.type, PayloadType.none);
   });
 }

--- a/packages/common_client/test/data_sources/fdv2/polling_base_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/polling_base_test.dart
@@ -85,6 +85,42 @@ String buildXferFullBody({
   });
 }
 
+/// A body that is structurally valid at the protocol level but whose
+/// flag-eval object has the wrong field types, so translation into a
+/// typed descriptor fails.
+String buildInvalidFlagBody({String state = 'sel-1', int version = 1}) {
+  return jsonEncode({
+    'events': [
+      {
+        'event': 'server-intent',
+        'data': {
+          'payloads': [
+            {
+              'id': 'p1',
+              'target': version,
+              'intentCode': 'xfer-full',
+              'reason': 'test',
+            }
+          ]
+        }
+      },
+      {
+        'event': 'put-object',
+        'data': {
+          'kind': 'flag-eval',
+          'key': 'my-flag',
+          'version': version,
+          'object': {'trackEvents': 'not-a-bool'},
+        }
+      },
+      {
+        'event': 'payload-transferred',
+        'data': {'state': state, 'version': version},
+      },
+    ]
+  });
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(LDLogRecord(
@@ -106,12 +142,26 @@ void main() {
 
       expect(result, isA<ChangeSetResult>());
       final cs = result as ChangeSetResult;
-      expect(cs.payload.type, equals(PayloadType.full));
-      expect(cs.payload.selector.state, equals('sel-99'));
-      expect(cs.payload.selector.version, equals(99));
-      expect(cs.payload.updates, hasLength(1));
-      expect(cs.payload.updates[0].key, equals('my-flag'));
+      expect(cs.changeSet.type, equals(PayloadType.full));
+      expect(cs.changeSet.selector.state, equals('sel-99'));
+      expect(cs.changeSet.selector.version, equals(99));
+      expect(cs.changeSet.updates, hasLength(1));
+      expect(cs.changeSet.updates.keys, contains('my-flag'));
       expect(cs.persist, isTrue);
+    });
+
+    test('a payload whose flag data cannot be parsed is interrupted', () async {
+      final mock = MockClient((request) async {
+        return http.Response(buildInvalidFlagBody(), 200);
+      });
+
+      final base = makePollingBase(mock);
+      final result = await base.pollOnce();
+
+      expect(result, isA<StatusResult>(),
+          reason: 'invalid flag data is a transient data error, not a '
+              'change set');
+      expect((result as StatusResult).state, equals(SourceState.interrupted));
     });
 
     test('propagates the x-ld-envid header to the result', () async {
@@ -150,8 +200,8 @@ void main() {
 
       expect(result, isA<ChangeSetResult>());
       final cs = result as ChangeSetResult;
-      expect(cs.payload.type, equals(PayloadType.none));
-      expect(cs.payload.updates, isEmpty);
+      expect(cs.changeSet.type, equals(PayloadType.none));
+      expect(cs.changeSet.updates, isEmpty);
       expect(cs.persist, isTrue);
     });
   });
@@ -399,8 +449,8 @@ void main() {
 
       expect(result, isA<ChangeSetResult>());
       final cs = result as ChangeSetResult;
-      expect(cs.payload.type, equals(PayloadType.none));
-      expect(cs.payload.updates, isEmpty);
+      expect(cs.changeSet.type, equals(PayloadType.none));
+      expect(cs.changeSet.updates, isEmpty);
     });
 
     test('heartbeat-only response is interrupted', () async {
@@ -513,8 +563,8 @@ void main() {
       expect(result, isA<ChangeSetResult>());
       final cs = result as ChangeSetResult;
       expect(cs.fdv1Fallback, isTrue);
-      expect(cs.payload.type, equals(PayloadType.full));
-      expect(cs.payload.updates, hasLength(1));
+      expect(cs.changeSet.type, equals(PayloadType.full));
+      expect(cs.changeSet.updates, hasLength(1));
     });
 
     test(
@@ -530,7 +580,7 @@ void main() {
       expect(result, isA<ChangeSetResult>());
       final cs = result as ChangeSetResult;
       expect(cs.fdv1Fallback, isTrue);
-      expect(cs.payload.type, equals(PayloadType.none));
+      expect(cs.changeSet.type, equals(PayloadType.none));
     });
 
     test('fallback on a non-recoverable 4xx still produces terminalError',

--- a/packages/common_client/test/data_sources/fdv2/polling_initializer_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/polling_initializer_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/payload.dart';
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/polling_initializer.dart';
+import 'package:launchdarkly_common_client/src/item_descriptor.dart';
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/selector.dart';
 import 'package:launchdarkly_common_client/src/data_sources/fdv2/source_result.dart';
 import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart';
@@ -42,15 +43,9 @@ class HoldingDelay {
 
 ChangeSetResult _changeSet({String flagKey = 'k', int version = 1}) =>
     ChangeSetResult(
-      payload: Payload(
+      changeSet: ChangeSet(
         type: PayloadType.full,
-        updates: [
-          Update(
-              kind: 'flag-eval',
-              key: flagKey,
-              version: version,
-              object: const {})
-        ],
+        updates: {flagKey: ItemDescriptor(version: version)},
       ),
       persist: true,
       freshness: DateTime.utc(2026, 1, 1),

--- a/packages/common_client/test/data_sources/fdv2/polling_synchronizer_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/polling_synchronizer_test.dart
@@ -84,12 +84,12 @@ class FakeTimer implements Timer {
 
 ChangeSetResult _changeSet({DateTime? freshness, String? selectorState}) =>
     ChangeSetResult(
-      payload: Payload(
+      changeSet: ChangeSet(
         type: PayloadType.full,
         selector: selectorState != null
             ? Selector(state: selectorState, version: 1)
             : Selector.empty,
-        updates: const [],
+        updates: const {},
       ),
       persist: true,
       freshness: freshness ?? DateTime.utc(2026, 1, 1),
@@ -175,7 +175,7 @@ void main() {
 
     expect(emissions, hasLength(2));
     expect(
-      (emissions[1] as ChangeSetResult).payload.selector.state,
+      (emissions[1] as ChangeSetResult).changeSet.selector.state,
       equals('second'),
     );
 

--- a/packages/common_client/test/data_sources/fdv2/requestor_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/requestor_test.dart
@@ -16,6 +16,7 @@ FDv2Requestor makeRequestor(
   bool withReasons = false,
   String contextEncoded = 'eyJrZXkiOiJ0ZXN0In0=',
   String contextJson = '{"key":"test"}',
+  Map<String, String> additionalQueryParameters = const {},
   HttpProperties? httpProperties,
 }) {
   return FDv2Requestor(
@@ -25,6 +26,7 @@ FDv2Requestor makeRequestor(
     contextJson: contextJson,
     usePost: usePost,
     withReasons: withReasons,
+    additionalQueryParameters: additionalQueryParameters,
     httpProperties: httpProperties ?? HttpProperties(),
     httpClientFactory: (props) =>
         HttpClient(client: innerClient, httpProperties: props),
@@ -56,6 +58,41 @@ void main() {
       expect(capturedMethod, equals('GET'));
       expect(capturedUri.path, equals('/sdk/poll/eval/ENC123'));
       expect(capturedUri.host, equals('example.test'));
+    });
+
+    test('does not add an authorization header', () async {
+      Map<String, String>? capturedHeaders;
+      final mock = MockClient((request) async {
+        capturedHeaders = request.headers;
+        return http.Response('{}', 200);
+      });
+
+      final requestor = makeRequestor(mock);
+      await requestor.request();
+
+      expect(capturedHeaders, isNot(contains('authorization')),
+          reason: 'authentication comes from the base headers or the '
+              'additional query parameters, never per-request');
+    });
+
+    test('includes the additional query parameters in every request URL',
+        () async {
+      final capturedUris = <Uri>[];
+      final mock = MockClient((request) async {
+        capturedUris.add(request.url);
+        return http.Response('{}', 200);
+      });
+
+      final requestor = makeRequestor(mock,
+          additionalQueryParameters: {'auth': 'the-client-side-id'});
+      await requestor.request();
+      await requestor.request(basis: Selector(state: 'st', version: 1));
+
+      expect(capturedUris, hasLength(2));
+      for (final uri in capturedUris) {
+        expect(uri.queryParameters, containsPair('auth', 'the-client-side-id'));
+      }
+      expect(capturedUris[1].queryParameters, containsPair('basis', 'st'));
     });
 
     test('does not send a body on GET', () async {

--- a/packages/common_client/test/data_sources/fdv2/source_factory_context_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/source_factory_context_test.dart
@@ -23,6 +23,7 @@ void main() {
       Future<CachedFlags?> reader(LDContext _) async => null;
 
       final ctx = SourceFactoryContext.fromClientConfig(
+        credential: 'test-credential',
         context: context,
         logger: logger,
         httpProperties: httpProperties,
@@ -51,6 +52,7 @@ void main() {
       Future<CachedFlags?> reader(LDContext _) async => null;
 
       final ctx = SourceFactoryContext.fromClientConfig(
+        credential: 'test-credential',
         context: context,
         logger: logger,
         httpProperties: HttpProperties(),
@@ -85,6 +87,7 @@ void main() {
       Future<CachedFlags?> reader(LDContext _) async => null;
 
       final ctx = SourceFactoryContext.fromClientConfig(
+        credential: 'test-credential',
         context: context,
         logger: logger,
         httpProperties: HttpProperties(),
@@ -116,6 +119,7 @@ void main() {
           HttpClient(httpProperties: p);
 
       final ctx = SourceFactoryContext.fromClientConfig(
+        credential: 'test-credential',
         context: context,
         logger: logger,
         httpProperties: httpProperties,

--- a/packages/common_client/test/data_sources/fdv2/streaming_base_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/streaming_base_test.dart
@@ -48,6 +48,17 @@ String putObject({
       'object': {'value': true, 'version': version, 'variation': 0},
     });
 
+/// A put-object that is structurally valid at the protocol level (the
+/// object is a JSON object with the required envelope fields) but whose
+/// flag-eval fields have the wrong types, so translation into a typed
+/// descriptor fails.
+String badPutObject({String key = 'flag-a', int version = 1}) => jsonEncode({
+      'kind': 'flag-eval',
+      'key': key,
+      'version': version,
+      'object': {'trackEvents': 'not-a-bool'},
+    });
+
 String payloadTransferred({String state = 'sel-1', int version = 1}) =>
     jsonEncode({
       'state': state,
@@ -221,11 +232,45 @@ void main() {
 
       expect(emissions, hasLength(1));
       final cs = emissions.single as ChangeSetResult;
-      expect(cs.payload.type, equals(PayloadType.full));
-      expect(cs.payload.selector.state, equals('sel-99'));
-      expect(cs.payload.updates.single.key, equals('k1'));
+      expect(cs.changeSet.type, equals(PayloadType.full));
+      expect(cs.changeSet.selector.state, equals('sel-99'));
+      expect(cs.changeSet.updates.keys.single, equals('k1'));
       expect(cs.persist, isTrue);
       expect(cs.freshness, equals(fixedNow));
+
+      await sub.cancel();
+    });
+
+    test(
+        'a payload whose flag data cannot be parsed surfaces interrupted, and '
+        'the connection recovers on the next valid payload', () async {
+      final sse = makeSse();
+      final base = makeBase(sse);
+      final emissions = <FDv2SourceResult>[];
+      final sub = base.results.listen(emissions.add);
+      await Future<void>.delayed(Duration.zero);
+
+      emitMessage(sse, 'server-intent', serverIntent());
+      emitMessage(sse, 'put-object', badPutObject());
+      emitMessage(sse, 'payload-transferred', payloadTransferred());
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emissions, hasLength(1));
+      expect(emissions.single, isA<StatusResult>(),
+          reason: 'invalid flag data is a transient data error, not a '
+              'change set');
+      expect((emissions.single as StatusResult).state,
+          equals(SourceState.interrupted));
+
+      // The SSE connection was not torn down: the server's next valid
+      // payload is processed by the fresh handler.
+      emitFullPayload(sse, state: 'sel-good', flagKey: 'good');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emissions, hasLength(2));
+      expect(emissions.last, isA<ChangeSetResult>());
+      expect((emissions.last as ChangeSetResult).changeSet.updates.keys.single,
+          equals('good'));
 
       await sub.cancel();
     });
@@ -372,7 +417,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       for (final result in emissions.whereType<ChangeSetResult>()) {
-        final keys = result.payload.updates.map((u) => u.key).toSet();
+        final keys = result.changeSet.updates.keys.toSet();
         expect(keys, isNot(contains('old-flag')),
             reason: 'old-flag from the previous connection bled into '
                 "the new connection's payload");
@@ -495,7 +540,7 @@ void main() {
         'the stream', () async {
       var pingCallCount = 0;
       final pingResult = ChangeSetResult(
-        payload: const Payload(type: PayloadType.full, updates: []),
+        changeSet: const ChangeSet(type: PayloadType.full, updates: {}),
         persist: true,
         freshness: DateTime.utc(2026, 1, 1),
       );

--- a/packages/common_client/test/data_sources/fdv2/streaming_synchronizer_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/streaming_synchronizer_test.dart
@@ -66,9 +66,9 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     expect(emissions, hasLength(2));
-    expect((emissions[0] as ChangeSetResult).payload.selector.state,
+    expect((emissions[0] as ChangeSetResult).changeSet.selector.state,
         equals('sel-1'));
-    expect((emissions[1] as ChangeSetResult).payload.selector.state,
+    expect((emissions[1] as ChangeSetResult).changeSet.selector.state,
         equals('sel-2'));
 
     await sub.cancel();


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: Translate FDv2 payloads at the data source layer
feat: Add FDv2 streaming source factories and query-parameter authentication
END_COMMIT_OVERRIDE

## What this changes

Moves flag-eval translation out of the apply path and into the data source layer, and introduces a typed `ChangeSet` distinct from the wire-level `Payload`.

Previously the streaming and polling sources emitted a `ChangeSetResult` carrying the raw wire `Payload` (a list of `Update`s with unparsed object maps), and the flag-eval objects were converted to typed descriptors later, at apply time in `DataSourceEventHandler.handlePayload`. A payload that parsed at the protocol level but whose flag objects were malformed therefore failed *after* acquisition — surfacing as an invalid-message that drove a connection restart, on a fixed interval, without ever arming the orchestrator's fallback timer.

Now:

- `ChangeSet` carries typed `Map<String, ItemDescriptor>` updates plus the type and selector. `translatePayload` converts a wire `Payload` into a `ChangeSet`, throwing if any flag-eval object cannot be parsed.
- The streaming and polling sources translate at acquisition. A translation failure becomes an **interrupted** source result, exactly like a malformed protocol body — so the orchestrator's fallback timer governs recovery (a source stuck on invalid data falls back after the timeout instead of retrying forever). Streaming discards the partial handler state and keeps the SSE connection; the server's next valid payload is processed normally.
- `ChangeSetResult` carries the `ChangeSet`, and `handlePayload` applies it directly with no conversion and no failure path of its own.
- The cache initializer builds its `ChangeSet` straight from the already-typed cached evaluation results, dropping a JSON round-trip that previously serialized typed results only to re-parse them.

This is foundational for the FDv2 data system: the streaming-source and orchestrator PRs build on `ChangeSet`. Nothing constructs the FDv2 sources in production yet, so behavior is unchanged for shipping code.

## Testing

Source-layer tests cover a protocol-valid payload whose flag data cannot be parsed: polling returns interrupted, and streaming returns interrupted then recovers on the next valid payload. The flag manager / event handler tests apply typed change sets directly (full replace, partial without per-item version comparison, none). Cache initializer tests assert the evaluation result is carried through without re-parsing. Full `common_client` suite passes.

SDK-2186

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches FDv2 acquisition, URL/auth composition, and error-classification paths that govern fallback and flag updates; changes are largely behind not-yet-production FDv2 wiring but alter recovery semantics when invalid flag data arrives.
> 
> **Overview**
> FDv2 now separates wire **`Payload`** from typed **`ChangeSet`** (`Map<String, ItemDescriptor>`). **`translatePayload`** runs in polling/streaming (and cache builds descriptors directly), so **`ChangeSetResult`** and **`handlePayload`** only apply already-typed updates.
> 
> **Malformed flag-eval data** is surfaced as **`interrupted`** at the source layer (like other transient parse errors) instead of failing later in the event handler—so the orchestrator’s fallback timer can kick in rather than endless connection retries.
> 
> Adds shared **`buildFDv2Uri`** (relay query params, `basis`, `withReasons`) for polling and streaming; **`SourceFactoryContext`** carries credential-driven **`auth`** query params. **Streaming synchronizer factories** are implemented (SSE client, per-reconnect URI/`basis`, legacy **`ping`** → one-shot poll, env ID fallback). Streaming also maps **`UnrecoverableStatusError`** to terminal errors with optional FDv1 fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38646ce5dd8d599079ccb69f9ded9fa5f5f90dda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->