### PR TITLE
feat: honor the FDv1 fallback directive on success, error, and goodbye

### DIFF
--- a/packages/common_client/lib/src/data_sources/fdv2/fallback_directive.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/fallback_directive.dart
@@ -1,0 +1,20 @@
+/// The FDv1 fallback directive parsed from a connection's response
+/// headers. Its presence means the server asked the SDK to fall back;
+/// [ttl] is how long to remain on the fallback before retrying FDv2
+/// (null when the server gave no TTL; [Duration.zero] means indefinitely).
+final class FallbackDirective {
+  final Duration? ttl;
+  const FallbackDirective(this.ttl);
+}
+
+/// Reads the FDv1 fallback directive from response headers, or null when
+/// the `x-ld-fd-fallback` header is not `"true"`. The single place that
+/// interprets these headers, shared by the streaming and polling sources.
+FallbackDirective? readFallbackDirective(Map<String, String> headers) {
+  if (headers['x-ld-fd-fallback']?.toLowerCase() != 'true') {
+    return null;
+  }
+  final raw = headers['x-ld-fd-fallback-ttl'];
+  final seconds = raw == null ? null : int.tryParse(raw);
+  return FallbackDirective(seconds == null ? null : Duration(seconds: seconds));
+}

--- a/packages/common_client/lib/src/data_sources/fdv2/orchestrator.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/orchestrator.dart
@@ -34,7 +34,7 @@ enum _SynchronizerOutcome {
   stop,
 }
 
-/// How the orchestrator responds to a server-directed FDv1 fallback.
+/// How the orchestrator responds to server-directed actions.
 enum _DirectiveAction {
   /// No directive present; carry on normally.
   none,

--- a/packages/common_client/lib/src/data_sources/fdv2/orchestrator.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/orchestrator.dart
@@ -34,6 +34,20 @@ enum _SynchronizerOutcome {
   stop,
 }
 
+/// How the orchestrator responds to a server-directed FDv1 fallback.
+enum _DirectiveAction {
+  /// No directive present; carry on normally.
+  none,
+
+  /// An FDv1 fallback tier exists and was engaged; advance to it.
+  engageFdv1Fallback,
+
+  /// The directive was received but no FDv1 fallback tier is configured.
+  /// The SDK stays interrupted and retries FDv2 after the directive's TTL
+  /// rather than removing the source.
+  deferRetry,
+}
+
 /// The FDv2 data source orchestrator.
 ///
 /// Runs the initializer chain to bring the SDK to a usable state, then
@@ -63,6 +77,18 @@ final class FDv2DataSourceOrchestrator implements DataSource {
   bool _closed = false;
   bool _emittedPayload = false;
   bool _initialized = false;
+
+  /// Default wait before retrying FDv2 after a fallback directive arrives
+  /// with no FDv1 fallback tier configured and no server-provided TTL.
+  static const Duration _defaultFallbackRetryInterval = Duration(hours: 1);
+
+  /// Overrides the next recycle delay when set (consumed once), used to
+  /// honor a fallback directive's retry TTL.
+  Duration? _pendingRetryDelay;
+
+  /// Completes when [stop] is called so a long interruptible wait (e.g. a
+  /// fallback retry delay) wakes promptly on shutdown.
+  final Completer<void> _stopCompleter = Completer<void>();
 
   /// True when the only sources are cache initializers (no synchronizers).
   /// Such a system must still reach a usable state on a cache miss, so an
@@ -117,6 +143,7 @@ final class FDv2DataSourceOrchestrator implements DataSource {
   void stop() {
     if (_closed) return;
     _closed = true;
+    if (!_stopCompleter.isCompleted) _stopCompleter.complete();
     _sourceManager.close();
     // Wake the active synchronizer run so it can observe the closed
     // state.
@@ -190,21 +217,51 @@ final class FDv2DataSourceOrchestrator implements DataSource {
     _controller.add(InitializedEvent());
   }
 
-  /// True when the source indicated an FDv1 fallback directive and a
-  /// fallback tier exists to engage. The directive is ignored when the
+  /// Classifies a server-directed FDv1 fallback and, for
+  /// [_DirectiveAction.engageFdv1Fallback], makes the source manager switch
+  /// tiers. The directive is ignored ([_DirectiveAction.none]) when the
   /// FDv1 fallback synchronizer is already the active source, so it cannot
-  /// loop (the fallback source also never re-asserts the directive).
-  bool _handleFdv1Fallback(FDv2SourceResult result) {
-    if (result.fdv1Fallback &&
-        _sourceManager.hasFdv1FallbackConfigured &&
-        !_sourceManager.isCurrentSynchronizerFdv1Fallback) {
+  /// loop (the fallback source also never re-asserts the directive). When
+  /// there is no FDv1 fallback tier we defer retrying FDv2
+  /// ([_DirectiveAction.deferRetry]).
+  _DirectiveAction _handleDirective(FDv2SourceResult result) {
+    if (!result.fdv1Fallback ||
+        _sourceManager.isCurrentSynchronizerFdv1Fallback) {
+      return _DirectiveAction.none;
+    }
+    if (_sourceManager.hasFdv1FallbackConfigured) {
       _logger.warn('Server directed fallback to FDv1; engaging the FDv1 '
           'fallback synchronizer.');
       _sourceManager.engageFdv1Fallback();
-      return true;
+      return _DirectiveAction.engageFdv1Fallback;
     }
-    return false;
+    return _DirectiveAction.deferRetry;
   }
+
+  /// Honors a fallback directive that has no FDv1 tier to engage: the SDK
+  /// stays interrupted and schedules an FDv2 retry after the directive's
+  /// TTL. A TTL of zero means remain indefinitely (no retry); an absent
+  /// TTL uses [_defaultFallbackRetryInterval].
+  void _scheduleFallbackRetry(
+      Duration? ttl, void Function(_SynchronizerOutcome) resolve) {
+    if (ttl == Duration.zero) {
+      _logger.warn('Server directed FDv1 fallback with no fallback tier '
+          'configured and an indefinite TTL; FDv2 updates are paused.');
+      resolve(_SynchronizerOutcome.stop);
+      return;
+    }
+    final delay = ttl ?? _defaultFallbackRetryInterval;
+    _logger.warn('Server directed FDv1 fallback but no fallback tier is '
+        'configured; staying interrupted and retrying FDv2 in '
+        '${delay.inSeconds}s.');
+    _pendingRetryDelay = delay;
+    resolve(_SynchronizerOutcome.recycle);
+  }
+
+  /// Waits [d], returning early if the orchestrator is stopped so a long
+  /// fallback-retry delay does not pin the run open past shutdown.
+  Future<void> _delay(Duration d) =>
+      Future.any([Future<void>.delayed(d), _stopCompleter.future]);
 
   Future<void> _runInitializers() async {
     var errorDuringInit = false;
@@ -225,19 +282,26 @@ final class FDv2DataSourceOrchestrator implements DataSource {
             _emitPayload(result);
             dataReceived = true;
 
-            if (_handleFdv1Fallback(result)) {
-              // Data was received but the server directed FDv1 fallback;
-              // move on to synchronizers where the fallback tier runs and
-              // its first change set completes initialization.
-              return;
-            }
-
-            if (result.changeSet.selector.isNotEmpty) {
-              // A selector means a complete, server-versioned payload:
-              // initialization is done. A selector-less payload (e.g. cache)
-              // is applied, but we keep initializing toward network data.
-              _emitInitialized();
-              return;
+            switch (_handleDirective(result)) {
+              case _DirectiveAction.engageFdv1Fallback:
+                // Data received but the server directed FDv1 fallback;
+                // move on to synchronizers where the fallback tier runs
+                // and its first change set completes initialization.
+                return;
+              case _DirectiveAction.deferRetry:
+                // An initializer is one-shot and cannot retry itself;
+                // let the chain exhaust and leave retry timing to the
+                // synchronizer tier.
+                break;
+              case _DirectiveAction.none:
+                if (result.changeSet.selector.isNotEmpty) {
+                  // A selector means a complete, server-versioned payload:
+                  // initialization is done. A selector-less payload (e.g.
+                  // cache) is applied, but we keep initializing toward
+                  // network data.
+                  _emitInitialized();
+                  return;
+                }
             }
           }
         case StatusResult():
@@ -253,7 +317,7 @@ final class FDv2DataSourceOrchestrator implements DataSource {
             case SourceState.goodbye:
               break;
           }
-          if (_handleFdv1Fallback(result)) {
+          if (_handleDirective(result) == _DirectiveAction.engageFdv1Fallback) {
             return;
           }
       }
@@ -298,8 +362,10 @@ final class FDv2DataSourceOrchestrator implements DataSource {
     while (!_closed) {
       if (recycleCurrent) {
         recycleCurrent = false;
-        if (_recycleDelay > Duration.zero) {
-          await Future<void>.delayed(_recycleDelay);
+        final delay = _pendingRetryDelay ?? _recycleDelay;
+        _pendingRetryDelay = null;
+        if (delay > Duration.zero) {
+          await _delay(delay);
           if (_closed) return;
         }
         synchronizer = _sourceManager.recreateCurrentSynchronizer();
@@ -393,12 +459,15 @@ final class FDv2DataSourceOrchestrator implements DataSource {
               _logger.warn('Synchronizer terminal error: '
                   '${result.message ?? 'unknown error'}');
               _reportTransientError(result);
-              if (_handleFdv1Fallback(result)) {
-                resolve(_SynchronizerOutcome.advance);
-                return;
+              switch (_handleDirective(result)) {
+                case _DirectiveAction.engageFdv1Fallback:
+                  resolve(_SynchronizerOutcome.advance);
+                case _DirectiveAction.deferRetry:
+                  _scheduleFallbackRetry(result.fdv1FallbackTtl, resolve);
+                case _DirectiveAction.none:
+                  _sourceManager.blockCurrentSynchronizer();
+                  resolve(_SynchronizerOutcome.advance);
               }
-              _sourceManager.blockCurrentSynchronizer();
-              resolve(_SynchronizerOutcome.advance);
               return;
             case SourceState.shutdown:
               // A synchronizer that shuts itself down before the system
@@ -421,8 +490,16 @@ final class FDv2DataSourceOrchestrator implements DataSource {
           }
       }
 
-      if (_handleFdv1Fallback(result)) {
-        resolve(_SynchronizerOutcome.advance);
+      switch (_handleDirective(result)) {
+        case _DirectiveAction.engageFdv1Fallback:
+          // A change set carrying the directive (e.g. a successful stream
+          // that delivered its basis then asked us to fall back) has been
+          // applied above; now advance to the fallback tier.
+          resolve(_SynchronizerOutcome.advance);
+        case _DirectiveAction.deferRetry:
+          _scheduleFallbackRetry(result.fdv1FallbackTtl, resolve);
+        case _DirectiveAction.none:
+          break;
       }
     }, onDone: () {
       if (outcome.isCompleted || _closed) return;

--- a/packages/common_client/lib/src/data_sources/fdv2/orchestrator.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/orchestrator.dart
@@ -224,7 +224,7 @@ final class FDv2DataSourceOrchestrator implements DataSource {
   /// loop (the fallback source also never re-asserts the directive). When
   /// there is no FDv1 fallback tier we defer retrying FDv2
   /// ([_DirectiveAction.deferRetry]).
-  _DirectiveAction _handleDirective(FDv2SourceResult result) {
+  _DirectiveAction _processDirective(FDv2SourceResult result) {
     if (!result.fdv1Fallback ||
         _sourceManager.isCurrentSynchronizerFdv1Fallback) {
       return _DirectiveAction.none;
@@ -282,7 +282,7 @@ final class FDv2DataSourceOrchestrator implements DataSource {
             _emitPayload(result);
             dataReceived = true;
 
-            switch (_handleDirective(result)) {
+            switch (_processDirective(result)) {
               case _DirectiveAction.engageFdv1Fallback:
                 // Data received but the server directed FDv1 fallback;
                 // move on to synchronizers where the fallback tier runs
@@ -317,7 +317,8 @@ final class FDv2DataSourceOrchestrator implements DataSource {
             case SourceState.goodbye:
               break;
           }
-          if (_handleDirective(result) == _DirectiveAction.engageFdv1Fallback) {
+          if (_processDirective(result) ==
+              _DirectiveAction.engageFdv1Fallback) {
             return;
           }
       }
@@ -459,7 +460,7 @@ final class FDv2DataSourceOrchestrator implements DataSource {
               _logger.warn('Synchronizer terminal error: '
                   '${result.message ?? 'unknown error'}');
               _reportTransientError(result);
-              switch (_handleDirective(result)) {
+              switch (_processDirective(result)) {
                 case _DirectiveAction.engageFdv1Fallback:
                   resolve(_SynchronizerOutcome.advance);
                 case _DirectiveAction.deferRetry:
@@ -490,7 +491,7 @@ final class FDv2DataSourceOrchestrator implements DataSource {
           }
       }
 
-      switch (_handleDirective(result)) {
+      switch (_processDirective(result)) {
         case _DirectiveAction.engageFdv1Fallback:
           // A change set carrying the directive (e.g. a successful stream
           // that delivered its basis then asked us to fall back) has been

--- a/packages/common_client/lib/src/data_sources/fdv2/polling_base.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/polling_base.dart
@@ -156,12 +156,20 @@ final class FDv2PollingBase {
               fdv1Fallback: fdv1Fallback,
               fdv1FallbackTtl: fdv1FallbackTtl,
             );
-          case ActionGoodbye(:final reason):
-            return FDv2SourceResults.goodbyeResult(
-              message: reason,
-              fdv1Fallback: fdv1Fallback,
-              fdv1FallbackTtl: fdv1FallbackTtl,
-            );
+          case ActionGoodbye(:final reason, :final protocolFallbackTtl):
+            // A goodbye can itself carry a fallback directive: in-band via
+            // protocolFallbackTtl, or via the response header. The
+            // orchestrator's goodbye path recycles without consulting the
+            // directive, so surface it as a terminal fallback result (as the
+            // streaming source does) rather than an ordinary goodbye.
+            if (protocolFallbackTtl != null || fdv1Fallback) {
+              return FDv2SourceResults.terminalError(
+                message: reason,
+                fdv1Fallback: true,
+                fdv1FallbackTtl: protocolFallbackTtl ?? fdv1FallbackTtl,
+              );
+            }
+            return FDv2SourceResults.goodbyeResult(message: reason);
           case ActionServerError(:final reason):
             return FDv2SourceResults.interrupted(
               message: reason,

--- a/packages/common_client/lib/src/data_sources/fdv2/polling_base.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/polling_base.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart';
 
+import 'fallback_directive.dart';
 import 'flag_eval_mapper.dart';
 import 'payload.dart';
 import 'protocol_handler.dart';
@@ -27,12 +28,14 @@ import 'source_result.dart';
 ///   through an [FDv2ProtocolHandler]. The first emitted action
 ///   determines the result.
 ///
-/// `x-ld-fd-fallback: true` is treated as an annotation on whatever
-/// result the response would otherwise produce: the body is still
-/// parsed and used, the 304 is still treated as no-op, errors are
-/// still classified by status code, and `fdv1Fallback: true` is
-/// stamped on the resulting [FDv2SourceResult]. The orchestrator can
-/// consume the data and transition to FDv1 in the same step.
+/// The `x-ld-fd-fallback` directive (read via [readFallbackDirective],
+/// shared with the streaming source) is treated as an annotation on
+/// whatever result the response would otherwise produce: the body is
+/// still parsed and used, the 304 is still treated as no-op, errors are
+/// still classified by status code, and `fdv1Fallback: true` plus the
+/// fallback TTL are stamped on the resulting [FDv2SourceResult]. The
+/// orchestrator can consume the data and transition to FDv1 in the same
+/// step.
 final class FDv2PollingBase {
   final LDLogger _logger;
   final FDv2Requestor _requestor;
@@ -65,9 +68,9 @@ final class FDv2PollingBase {
   }
 
   FDv2SourceResult _processResponse(RequestorResponse response) {
-    // Match `x-ld-fd-fallback` case-insensitively.
-    final fdv1Fallback =
-        response.headers['x-ld-fd-fallback']?.toLowerCase() == 'true';
+    final directive = readFallbackDirective(response.headers);
+    final fdv1Fallback = directive != null;
+    final fdv1FallbackTtl = directive?.ttl;
     final environmentId = response.headers['x-ld-envid'];
 
     // 304 Not Modified means the SDK's cached data is confirmed current.
@@ -78,6 +81,7 @@ final class FDv2PollingBase {
         freshness: _now(),
         persist: true,
         fdv1Fallback: fdv1Fallback,
+        fdv1FallbackTtl: fdv1FallbackTtl,
       );
     }
 
@@ -89,6 +93,7 @@ final class FDv2PollingBase {
           statusCode: response.status,
           message: message,
           fdv1Fallback: fdv1Fallback,
+          fdv1FallbackTtl: fdv1FallbackTtl,
         );
       }
       _logger.error('$message; will not retry');
@@ -96,6 +101,7 @@ final class FDv2PollingBase {
         statusCode: response.status,
         message: message,
         fdv1Fallback: fdv1Fallback,
+        fdv1FallbackTtl: fdv1FallbackTtl,
       );
     }
 
@@ -103,6 +109,7 @@ final class FDv2PollingBase {
       response,
       environmentId: environmentId,
       fdv1Fallback: fdv1Fallback,
+      fdv1FallbackTtl: fdv1FallbackTtl,
     );
   }
 
@@ -110,6 +117,7 @@ final class FDv2PollingBase {
     RequestorResponse response, {
     String? environmentId,
     required bool fdv1Fallback,
+    required Duration? fdv1FallbackTtl,
   }) {
     // The whole parse path is wrapped: jsonDecode plus the structural
     // casts inside FDv2EventsCollection.fromJson and the per-event
@@ -122,6 +130,7 @@ final class FDv2PollingBase {
           statusCode: response.status,
           message: 'Polling response was not a JSON object',
           fdv1Fallback: fdv1Fallback,
+          fdv1FallbackTtl: fdv1FallbackTtl,
         );
       }
 
@@ -145,21 +154,25 @@ final class FDv2PollingBase {
               freshness: _now(),
               persist: true,
               fdv1Fallback: fdv1Fallback,
+              fdv1FallbackTtl: fdv1FallbackTtl,
             );
           case ActionGoodbye(:final reason):
             return FDv2SourceResults.goodbyeResult(
               message: reason,
               fdv1Fallback: fdv1Fallback,
+              fdv1FallbackTtl: fdv1FallbackTtl,
             );
           case ActionServerError(:final reason):
             return FDv2SourceResults.interrupted(
               message: reason,
               fdv1Fallback: fdv1Fallback,
+              fdv1FallbackTtl: fdv1FallbackTtl,
             );
           case ActionError(:final message):
             return FDv2SourceResults.interrupted(
               message: message,
               fdv1Fallback: fdv1Fallback,
+              fdv1FallbackTtl: fdv1FallbackTtl,
             );
           case ActionNone():
             // Continue accumulating events until a payload-transferred or
@@ -175,6 +188,7 @@ final class FDv2PollingBase {
         statusCode: response.status,
         message: 'Polling response did not include a complete payload',
         fdv1Fallback: fdv1Fallback,
+        fdv1FallbackTtl: fdv1FallbackTtl,
       );
     } catch (err, stack) {
       // Log only the type at error level (not the message — `jsonDecode`
@@ -187,6 +201,7 @@ final class FDv2PollingBase {
         statusCode: response.status,
         message: 'Polling response body was malformed',
         fdv1Fallback: fdv1Fallback,
+        fdv1FallbackTtl: fdv1FallbackTtl,
       );
     }
   }

--- a/packages/common_client/lib/src/data_sources/fdv2/protocol_handler.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/protocol_handler.dart
@@ -54,7 +54,14 @@ final class ActionError extends ProtocolAction {
 /// The server intends to disconnect.
 final class ActionGoodbye extends ProtocolAction {
   final String reason;
-  const ActionGoodbye(this.reason);
+
+  /// When present, the goodbye carries an in-band protocol-fallback
+  /// directive (FDv2 to FDv1) with this time-to-live; [Duration.zero]
+  /// means remain on the fallback indefinitely. `null` means an ordinary
+  /// disconnect with no fallback directive.
+  final Duration? protocolFallbackTtl;
+
+  const ActionGoodbye(this.reason, {this.protocolFallbackTtl});
 }
 
 /// A server-side application error was encountered.
@@ -259,7 +266,8 @@ final class FDv2ProtocolHandler {
   ProtocolAction _processGoodbye(GoodbyeEvent data) {
     _logger.info('Goodbye received from LaunchDarkly: ${data.reason}');
     reset();
-    return ActionGoodbye(data.reason);
+    return ActionGoodbye(data.reason,
+        protocolFallbackTtl: data.protocolFallbackTtl);
   }
 
   ProtocolAction _processError(ServerErrorEvent data) {

--- a/packages/common_client/lib/src/data_sources/fdv2/protocol_types.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/protocol_types.dart
@@ -149,15 +149,25 @@ final class GoodbyeEvent {
   final String reason;
   final bool silent;
 
+  /// When present, the server is directing a protocol fallback (FDv2 to
+  /// FDv1) in-band -- the same signal as the `x-ld-fd-fallback` response
+  /// header, for transports that cannot read response headers. The value
+  /// is how long to remain on the fallback before retrying; [Duration.zero]
+  /// means indefinitely. `null` means no fallback was directed.
+  final Duration? protocolFallbackTtl;
+
   const GoodbyeEvent({
     required this.reason,
     this.silent = false,
+    this.protocolFallbackTtl,
   });
 
   factory GoodbyeEvent.fromJson(Map<String, dynamic> json) {
+    final ttl = json['protocolFallbackTTL'];
     return GoodbyeEvent(
       reason: json['reason'] as String? ?? '',
       silent: json['silent'] as bool? ?? false,
+      protocolFallbackTtl: ttl is num ? Duration(seconds: ttl.toInt()) : null,
     );
   }
 }

--- a/packages/common_client/lib/src/data_sources/fdv2/source_result.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/source_result.dart
@@ -20,7 +20,13 @@ sealed class FDv2SourceResult {
   /// Whether the server indicated FDv1 fallback is needed.
   final bool fdv1Fallback;
 
-  const FDv2SourceResult({this.fdv1Fallback = false});
+  /// How long to remain on the fallback before retrying FDv2, when
+  /// [fdv1Fallback] is set. `null` means the server gave no time-to-live
+  /// (the caller applies its default); [Duration.zero] means remain
+  /// indefinitely with no automatic retry.
+  final Duration? fdv1FallbackTtl;
+
+  const FDv2SourceResult({this.fdv1Fallback = false, this.fdv1FallbackTtl});
 }
 
 /// A data payload was received and translated into typed descriptors.
@@ -43,6 +49,7 @@ final class ChangeSetResult extends FDv2SourceResult {
     this.environmentId,
     this.freshness,
     super.fdv1Fallback,
+    super.fdv1FallbackTtl,
   });
 
   @override
@@ -72,6 +79,7 @@ final class StatusResult extends FDv2SourceResult {
     this.message,
     this.statusCode,
     super.fdv1Fallback,
+    super.fdv1FallbackTtl,
   });
 
   @override
@@ -87,6 +95,7 @@ abstract final class FDv2SourceResults {
     String? environmentId,
     DateTime? freshness,
     bool fdv1Fallback = false,
+    Duration? fdv1FallbackTtl,
   }) =>
       ChangeSetResult(
         changeSet: changeSet,
@@ -94,18 +103,21 @@ abstract final class FDv2SourceResults {
         environmentId: environmentId,
         freshness: freshness,
         fdv1Fallback: fdv1Fallback,
+        fdv1FallbackTtl: fdv1FallbackTtl,
       );
 
   static StatusResult interrupted({
     String? message,
     int? statusCode,
     bool fdv1Fallback = false,
+    Duration? fdv1FallbackTtl,
   }) =>
       StatusResult(
         state: SourceState.interrupted,
         message: message,
         statusCode: statusCode,
         fdv1Fallback: fdv1Fallback,
+        fdv1FallbackTtl: fdv1FallbackTtl,
       );
 
   static StatusResult shutdown({
@@ -122,12 +134,14 @@ abstract final class FDv2SourceResults {
     String? message,
     int? statusCode,
     bool fdv1Fallback = false,
+    Duration? fdv1FallbackTtl,
   }) =>
       StatusResult(
         state: SourceState.terminalError,
         message: message,
         statusCode: statusCode,
         fdv1Fallback: fdv1Fallback,
+        fdv1FallbackTtl: fdv1FallbackTtl,
       );
 
   static StatusResult goodbyeResult({

--- a/packages/common_client/lib/src/data_sources/fdv2/source_result.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/source_result.dart
@@ -147,10 +147,12 @@ abstract final class FDv2SourceResults {
   static StatusResult goodbyeResult({
     String? message,
     bool fdv1Fallback = false,
+    Duration? fdv1FallbackTtl,
   }) =>
       StatusResult(
         state: SourceState.goodbye,
         message: message,
         fdv1Fallback: fdv1Fallback,
+        fdv1FallbackTtl: fdv1FallbackTtl,
       );
 }

--- a/packages/common_client/lib/src/data_sources/fdv2/streaming_base.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/streaming_base.dart
@@ -271,16 +271,24 @@ final class FDv2StreamingBase {
       case ActionGoodbye(:final reason, :final protocolFallbackTtl):
         // Server told us to disconnect; route through the terminal
         // helper so a close() from the listener's onData -- a natural
-        // reaction to a goodbye -- doesn't race with our own close. A
-        // goodbye carrying a protocol-fallback TTL is an in-band fallback
-        // directive (used by transports that cannot read response
-        // headers); surface it as such instead of an ordinary goodbye.
+        // reaction to a goodbye -- doesn't race with our own close.
+        //
+        // A goodbye can carry a fallback directive: in-band via its
+        // protocol-fallback TTL, or from this connection's
+        // x-ld-fd-fallback header (pending from open, if no payload has
+        // consumed it yet). The orchestrator's goodbye path recycles
+        // without consulting the directive, so surface it as a terminal
+        // fallback result -- otherwise a header-only directive followed by
+        // a goodbye would loop on reconnect instead of falling back.
+        final hasDirective =
+            protocolFallbackTtl != null || _pendingDirective != null;
         _terminate(
-            finalResult: protocolFallbackTtl != null
+            finalResult: hasDirective
                 ? FDv2SourceResults.terminalError(
                     message: 'Server requested FDv1 fallback (goodbye)',
                     fdv1Fallback: true,
-                    fdv1FallbackTtl: protocolFallbackTtl,
+                    fdv1FallbackTtl:
+                        protocolFallbackTtl ?? _pendingDirective?.ttl,
                   )
                 : FDv2SourceResults.goodbyeResult(message: reason));
       case ActionServerError(:final reason):

--- a/packages/common_client/lib/src/data_sources/fdv2/streaming_base.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/streaming_base.dart
@@ -12,6 +12,28 @@ import 'protocol_types.dart';
 import 'source.dart';
 import 'source_result.dart';
 
+/// The FDv1 fallback directive parsed from a connection's response
+/// headers. Its presence means the server asked the SDK to fall back;
+/// [ttl] is how long to remain on the fallback before retrying FDv2
+/// (null when the server gave no TTL; [Duration.zero] means indefinitely).
+final class _FallbackDirective {
+  final Duration? ttl;
+  const _FallbackDirective(this.ttl);
+}
+
+/// Reads the FDv1 fallback directive from response headers, or null when
+/// the `x-ld-fd-fallback` header is not `"true"`. The single place that
+/// interprets these headers, used for both successful and error responses.
+_FallbackDirective? _readFallbackDirective(Map<String, String> headers) {
+  if (headers['x-ld-fd-fallback']?.toLowerCase() != 'true') {
+    return null;
+  }
+  final raw = headers['x-ld-fd-fallback-ttl'];
+  final seconds = raw == null ? null : int.tryParse(raw);
+  return _FallbackDirective(
+      seconds == null ? null : Duration(seconds: seconds));
+}
+
 /// Long-lived streaming data source over SSE.
 ///
 /// Wraps an [SSEClient] with FDv2 protocol semantics. Each named SSE
@@ -33,9 +55,15 @@ import 'source_result.dart';
 /// Legacy `ping` events are routed to the injected [PingHandler] (which
 /// performs a one-shot poll) and the result is forwarded to the stream.
 ///
-/// The `x-ld-fd-fallback` header on the initial connection's response
-/// is detected and produces a terminal-error result with
-/// `fdv1Fallback: true`. The connection is closed.
+/// The FDv1 fallback directive is detected from three places: the
+/// `x-ld-fd-fallback` header on a successful connection's response, the
+/// same header on any error response ([SseHttpError], recoverable or not),
+/// and a `goodbye` event's `protocolFallbackTTL` (the in-band signal for
+/// transports that cannot read response headers). On a successful
+/// connection the directive is emitted with the basis change set so the
+/// payload is applied before the SDK falls back; otherwise it produces a
+/// terminal-error result. Either way the result carries `fdv1Fallback:
+/// true` and the fallback TTL.
 ///
 /// Lifecycle: a single-subscription stream. [results] starts the SSE
 /// connection on subscribe. [close] stops the source, emits a shutdown
@@ -60,6 +88,13 @@ final class FDv2StreamingBase {
   String? _environmentId;
   bool _pingInFlight = false;
   bool _pingPending = false;
+
+  /// Set when a successful connection's response carried the FDv1 fallback
+  /// directive. The directive is emitted with the next change set, so the
+  /// basis delivered alongside it is applied before the SDK falls back (a
+  /// successful stream that says "fall back" still hands over its current
+  /// data first). Cleared once emitted.
+  _FallbackDirective? _pendingDirective;
 
   FDv2StreamingBase({
     required SSEClient sseClient,
@@ -175,17 +210,11 @@ final class FDv2StreamingBase {
       _environmentId = envId;
     }
 
-    final fallback = headers['x-ld-fd-fallback']?.toLowerCase() == 'true';
-    if (fallback) {
-      // Server told us to fall back; route through the terminal helper
-      // so a close() from the listener's onData -- a natural reaction
-      // to a fallback signal -- doesn't race with our own close.
-      _terminate(
-          finalResult: FDv2SourceResults.terminalError(
-        message: 'Server requested FDv1 fallback',
-        fdv1Fallback: true,
-      ));
-    }
+    // A successful connection that directs fallback still delivers its
+    // current basis first. Defer the directive so it is emitted with the
+    // next change set: the payload is applied, then the SDK falls back.
+    // Terminating here would drop the basis the server just sent.
+    _pendingDirective = _readFallbackDirective(headers);
   }
 
   Future<void> _handleMessage(MessageEvent event) async {
@@ -254,13 +283,27 @@ final class FDv2StreamingBase {
           environmentId: _environmentId,
           freshness: freshness,
           persist: true,
+          // A directive seen on this connection's response is emitted with
+          // the basis so it is applied before the orchestrator falls back.
+          fdv1Fallback: _pendingDirective != null,
+          fdv1FallbackTtl: _pendingDirective?.ttl,
         ));
-      case ActionGoodbye(:final reason):
+        _pendingDirective = null;
+      case ActionGoodbye(:final reason, :final protocolFallbackTtl):
         // Server told us to disconnect; route through the terminal
         // helper so a close() from the listener's onData -- a natural
-        // reaction to a goodbye -- doesn't race with our own close.
+        // reaction to a goodbye -- doesn't race with our own close. A
+        // goodbye carrying a protocol-fallback TTL is an in-band fallback
+        // directive (used by transports that cannot read response
+        // headers); surface it as such instead of an ordinary goodbye.
         _terminate(
-            finalResult: FDv2SourceResults.goodbyeResult(message: reason));
+            finalResult: protocolFallbackTtl != null
+                ? FDv2SourceResults.terminalError(
+                    message: 'Server requested FDv1 fallback (goodbye)',
+                    fdv1Fallback: true,
+                    fdv1FallbackTtl: protocolFallbackTtl,
+                  )
+                : FDv2SourceResults.goodbyeResult(message: reason));
       case ActionServerError(:final reason):
         _emit(FDv2SourceResults.interrupted(message: reason));
       case ActionError(:final message):
@@ -317,26 +360,46 @@ final class FDv2StreamingBase {
   void _handleSseError(Object err, StackTrace stack) {
     if (_stoppedSignal.isCompleted) return;
 
-    if (err is UnrecoverableStatusError) {
-      // The SSE client stops reconnecting for these status codes, so the
-      // source cannot recover on its own. Surface a terminal error so the
-      // orchestrator moves to another source. The error response may also
-      // carry the FDv1 fallback directive.
-      final fallback = err.headers['x-ld-fd-fallback']?.toLowerCase() == 'true';
-      _logger.warn(
-          'Streaming request failed with status ${err.statusCode}; giving up');
+    if (err is SseHttpError) {
+      final message = 'Streaming request failed with status ${err.statusCode}';
+
+      // A fallback directive on the response takes precedence over the
+      // status: tear down this connection (which stops any retry the
+      // client scheduled) and route to the fallback tier.
+      if (_readFallbackDirective(err.headers) case final directive?) {
+        _logger.warn('$message; server requested FDv1 fallback');
+        _terminate(
+            finalResult: FDv2SourceResults.terminalError(
+          message: message,
+          statusCode: err.statusCode,
+          fdv1Fallback: true,
+          fdv1FallbackTtl: directive.ttl,
+        ));
+        return;
+      }
+
+      if (err.recoverable) {
+        // The client retries on its own (and logs the error); surface the
+        // disruption as interrupted and stay connected to it.
+        _emit(FDv2SourceResults.interrupted(
+            message: message, statusCode: err.statusCode));
+        return;
+      }
+
+      // Not recoverable and no directive: the client has stopped, so this
+      // source cannot recover. Surface a terminal error so the orchestrator
+      // moves on.
+      _logger.warn('$message; giving up');
       _terminate(
           finalResult: FDv2SourceResults.terminalError(
-        message: 'Streaming request failed with status ${err.statusCode}',
+        message: message,
         statusCode: err.statusCode,
-        fdv1Fallback: fallback,
       ));
       return;
     }
 
-    // The SSE client's built-in backoff handles reconnection. Surface
-    // the disruption as interrupted; the orchestrator decides whether
-    // to fall through to a different source after enough time.
+    // A transport-level error (no HTTP status). The SSE client's built-in
+    // backoff handles reconnection; surface the disruption as interrupted.
     //
     // Don't log the raw exception. http.ClientException's toString
     // formats as 'ClientException: <msg>, uri=<full-url>', and in GET

--- a/packages/common_client/lib/src/data_sources/fdv2/streaming_base.dart
+++ b/packages/common_client/lib/src/data_sources/fdv2/streaming_base.dart
@@ -5,34 +5,13 @@ import 'package:http/http.dart' as http;
 import 'package:launchdarkly_dart_common/launchdarkly_dart_common.dart';
 import 'package:launchdarkly_event_source_client/launchdarkly_event_source_client.dart';
 
+import 'fallback_directive.dart';
 import 'flag_eval_mapper.dart';
 import 'payload.dart';
 import 'protocol_handler.dart';
 import 'protocol_types.dart';
 import 'source.dart';
 import 'source_result.dart';
-
-/// The FDv1 fallback directive parsed from a connection's response
-/// headers. Its presence means the server asked the SDK to fall back;
-/// [ttl] is how long to remain on the fallback before retrying FDv2
-/// (null when the server gave no TTL; [Duration.zero] means indefinitely).
-final class _FallbackDirective {
-  final Duration? ttl;
-  const _FallbackDirective(this.ttl);
-}
-
-/// Reads the FDv1 fallback directive from response headers, or null when
-/// the `x-ld-fd-fallback` header is not `"true"`. The single place that
-/// interprets these headers, used for both successful and error responses.
-_FallbackDirective? _readFallbackDirective(Map<String, String> headers) {
-  if (headers['x-ld-fd-fallback']?.toLowerCase() != 'true') {
-    return null;
-  }
-  final raw = headers['x-ld-fd-fallback-ttl'];
-  final seconds = raw == null ? null : int.tryParse(raw);
-  return _FallbackDirective(
-      seconds == null ? null : Duration(seconds: seconds));
-}
 
 /// Long-lived streaming data source over SSE.
 ///
@@ -94,7 +73,7 @@ final class FDv2StreamingBase {
   /// basis delivered alongside it is applied before the SDK falls back (a
   /// successful stream that says "fall back" still hands over its current
   /// data first). Cleared once emitted.
-  _FallbackDirective? _pendingDirective;
+  FallbackDirective? _pendingDirective;
 
   FDv2StreamingBase({
     required SSEClient sseClient,
@@ -214,7 +193,7 @@ final class FDv2StreamingBase {
     // current basis first. Defer the directive so it is emitted with the
     // next change set: the payload is applied, then the SDK falls back.
     // Terminating here would drop the basis the server just sent.
-    _pendingDirective = _readFallbackDirective(headers);
+    _pendingDirective = readFallbackDirective(headers);
   }
 
   Future<void> _handleMessage(MessageEvent event) async {
@@ -366,7 +345,7 @@ final class FDv2StreamingBase {
       // A fallback directive on the response takes precedence over the
       // status: tear down this connection (which stops any retry the
       // client scheduled) and route to the fallback tier.
-      if (_readFallbackDirective(err.headers) case final directive?) {
+      if (readFallbackDirective(err.headers) case final directive?) {
         _logger.warn('$message; server requested FDv1 fallback');
         _terminate(
             finalResult: FDv2SourceResults.terminalError(

--- a/packages/common_client/lib/src/data_sources/streaming_data_source.dart
+++ b/packages/common_client/lib/src/data_sources/streaming_data_source.dart
@@ -198,6 +198,12 @@ final class StreamingDataSource implements DataSource {
         if (_permanentShutdown) {
           return;
         }
+        // The SSE client retries recoverable responses on its own (and
+        // logs them), so this source is not shutting down -- let the retry
+        // run.
+        if (err is SseHttpError && err.recoverable) {
+          return;
+        }
         _permanentShutdown = true;
         _logger.error(
             'Encountered an unrecoverable error: "$err", Shutting down.');

--- a/packages/common_client/test/data_sources/fdv2/orchestrator_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/orchestrator_test.dart
@@ -512,6 +512,124 @@ void main() {
     harness.orchestrator.stop();
   });
 
+  test(
+      'a change set carrying the directive is applied before the fallback '
+      'tier engages', () async {
+    final fdv2Tier = <FakeSynchronizer>[];
+    final fdv1Tier = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [
+        synchronizerSlot(fdv2Tier),
+        synchronizerSlot(fdv1Tier, isFdv1Fallback: true),
+      ],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    // A successful connection delivered its basis and carried the directive
+    // on the same change set.
+    fdv2Tier.single.controller.add(changeSet(
+        selector: const Selector(state: 'from-stream', version: 1),
+        fdv1Fallback: true));
+    await harness.pump();
+
+    // The payload was applied (emitted + selector adopted) before the
+    // fallback tier was engaged.
+    expect(harness.events.whereType<PayloadEvent>(), hasLength(1));
+    expect(harness.selector.state, 'from-stream');
+    expect(fdv1Tier, hasLength(1), reason: 'the fallback tier then engages');
+
+    harness.orchestrator.stop();
+  });
+
+  test(
+      'a directive with no fallback tier stays interrupted and retries FDv2 '
+      'after the TTL', () async {
+    final fdv2Tier = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [synchronizerSlot(fdv2Tier)],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    fdv2Tier.first.controller.add(FDv2SourceResults.terminalError(
+        message: 'fall back',
+        fdv1Fallback: true,
+        fdv1FallbackTtl: const Duration(milliseconds: 30)));
+    await harness.pump();
+
+    // No fallback tier exists, so the system is not halted; it has not yet
+    // retried either (the TTL has not elapsed).
+    expect(harness.events.whereType<StatusEvent>(), isEmpty,
+        reason: 'the directive does not halt the data system');
+    expect(fdv2Tier, hasLength(1));
+
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+    await harness.pump();
+
+    expect(fdv2Tier, hasLength(2),
+        reason: 'the FDv2 synchronizer is retried once the TTL elapses');
+
+    harness.orchestrator.stop();
+  });
+
+  test(
+      'a directive with no fallback tier and no TTL does not reconnect '
+      'promptly (defaults to a long retry interval)', () async {
+    final fdv2Tier = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [synchronizerSlot(fdv2Tier)],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    fdv2Tier.first.controller.add(FDv2SourceResults.terminalError(
+        message: 'fall back', fdv1Fallback: true));
+    await harness.pump();
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    await harness.pump();
+
+    expect(harness.events.whereType<StatusEvent>(), isEmpty);
+    expect(fdv2Tier, hasLength(1),
+        reason: 'with no TTL the default retry interval is long, so no '
+            'reconnect is observed in the test window');
+
+    harness.orchestrator.stop();
+  });
+
+  test(
+      'a directive with no fallback tier and a zero TTL pauses FDv2 with no '
+      'retry', () async {
+    final fdv2Tier = <FakeSynchronizer>[];
+    final harness = Harness(
+      initializerFactories: [],
+      synchronizerSlots: [synchronizerSlot(fdv2Tier)],
+    );
+
+    harness.orchestrator.start();
+    await harness.pump();
+
+    fdv2Tier.first.controller.add(FDv2SourceResults.terminalError(
+        message: 'fall back',
+        fdv1Fallback: true,
+        fdv1FallbackTtl: Duration.zero));
+    await harness.pump();
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+    await harness.pump();
+
+    expect(harness.events.whereType<StatusEvent>(), isEmpty,
+        reason: 'pausing is not a halt');
+    expect(fdv2Tier, hasLength(1), reason: 'a zero TTL means no retry');
+
+    harness.orchestrator.stop();
+  });
+
   test('recovery condition returns to the primary synchronizer', () async {
     final primary = <FakeSynchronizer>[];
     final secondary = <FakeSynchronizer>[];

--- a/packages/common_client/test/data_sources/fdv2/polling_base_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/polling_base_test.dart
@@ -390,6 +390,51 @@ void main() {
       expect((result as StatusResult).state, equals(SourceState.goodbye));
     });
 
+    test(
+        'a goodbye carrying protocolFallbackTTL becomes a terminal fallback '
+        'directive (no fallback header needed)', () async {
+      final body = jsonEncode({
+        'events': [
+          {
+            'event': 'goodbye',
+            'data': {'reason': 'fall back', 'protocolFallbackTTL': 90}
+          },
+        ]
+      });
+      final mock = MockClient((request) async {
+        return http.Response(body, 200);
+      });
+
+      final base = makePollingBase(mock);
+      final result = await base.pollOnce();
+
+      expect((result as StatusResult).state, equals(SourceState.terminalError));
+      expect(result.fdv1Fallback, isTrue);
+      expect(result.fdv1FallbackTtl, equals(const Duration(seconds: 90)));
+    });
+
+    test(
+        'a goodbye with the fallback header becomes a terminal fallback '
+        'directive', () async {
+      final body = jsonEncode({
+        'events': [
+          {
+            'event': 'goodbye',
+            'data': {'reason': 'maintenance'}
+          },
+        ]
+      });
+      final mock = MockClient((request) async {
+        return http.Response(body, 200, headers: {'x-ld-fd-fallback': 'true'});
+      });
+
+      final base = makePollingBase(mock);
+      final result = await base.pollOnce();
+
+      expect((result as StatusResult).state, equals(SourceState.terminalError));
+      expect(result.fdv1Fallback, isTrue);
+    });
+
     test('server error event produces interrupted', () async {
       final body = jsonEncode({
         'events': [

--- a/packages/common_client/test/data_sources/fdv2/polling_base_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/polling_base_test.dart
@@ -648,6 +648,34 @@ void main() {
       expect(result, isA<ChangeSetResult>());
       expect(result.fdv1Fallback, isFalse);
     });
+
+    test('the fallback TTL header is carried onto the result', () async {
+      final mock = MockClient((request) async {
+        return http.Response(buildXferFullBody(), 200, headers: {
+          'x-ld-fd-fallback': 'true',
+          'x-ld-fd-fallback-ttl': '300',
+        });
+      });
+
+      final base = makePollingBase(mock);
+      final result = await base.pollOnce();
+
+      expect(result.fdv1Fallback, isTrue);
+      expect(result.fdv1FallbackTtl, equals(const Duration(seconds: 300)));
+    });
+
+    test('a directive with no TTL header leaves the TTL null', () async {
+      final mock = MockClient((request) async {
+        return http.Response(buildXferFullBody(), 200,
+            headers: {'x-ld-fd-fallback': 'true'});
+      });
+
+      final base = makePollingBase(mock);
+      final result = await base.pollOnce();
+
+      expect(result.fdv1Fallback, isTrue);
+      expect(result.fdv1FallbackTtl, isNull);
+    });
   });
 
   group('error message sanitization', () {

--- a/packages/common_client/test/data_sources/fdv2/protocol_handler_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/protocol_handler_test.dart
@@ -423,7 +423,32 @@ void main() {
           event: FDv2EventTypes.goodbye, data: {'reason': 'maintenance'}));
       expect(action, isA<ActionGoodbye>());
       expect((action as ActionGoodbye).reason, equals('maintenance'));
+      expect(action.protocolFallbackTtl, isNull,
+          reason: 'an ordinary goodbye carries no fallback directive');
       expect(handler.state, equals(ProtocolState.inactive));
+    });
+
+    test('carries the protocolFallbackTTL as an in-band fallback directive',
+        () {
+      final handler = makeHandler();
+      handler.processEvent(serverIntent('xfer-full'));
+
+      final action = handler.processEvent(FDv2Event(
+          event: FDv2EventTypes.goodbye,
+          data: {'reason': 'fall back', 'protocolFallbackTTL': 60}));
+      expect((action as ActionGoodbye).protocolFallbackTtl,
+          equals(const Duration(seconds: 60)));
+    });
+
+    test('a zero protocolFallbackTTL is preserved (indefinite fallback)', () {
+      final handler = makeHandler();
+      handler.processEvent(serverIntent('xfer-full'));
+
+      final action = handler.processEvent(FDv2Event(
+          event: FDv2EventTypes.goodbye,
+          data: {'reason': 'fall back', 'protocolFallbackTTL': 0}));
+      expect(
+          (action as ActionGoodbye).protocolFallbackTtl, equals(Duration.zero));
     });
   });
 

--- a/packages/common_client/test/data_sources/fdv2/streaming_base_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/streaming_base_test.dart
@@ -192,7 +192,9 @@ void main() {
         'close() is safe to call from a listener reacting to an FDv1 '
         'fallback', () async {
       // Same race risk as the goodbye case, but for the fdv1-fallback
-      // terminal branch.
+      // terminal branch -- here driven by a goodbye carrying a
+      // protocol-fallback TTL, which surfaces as a terminal fallback
+      // result.
       final sse = makeSse();
       final base = makeBase(sse);
       Object? caught;
@@ -205,7 +207,9 @@ void main() {
       }, (err, _) => caught = err);
 
       await Future<void>.delayed(Duration.zero);
-      emitOpen(sse, headers: {'x-ld-fd-fallback': 'true'});
+      emitOpen(sse);
+      emitMessage(sse, 'goodbye',
+          jsonEncode({'reason': 'fall back', 'protocolFallbackTTL': 60}));
       for (var i = 0; i < 5; i++) {
         await Future<void>.delayed(Duration.zero);
       }
@@ -480,25 +484,52 @@ void main() {
     });
   });
 
-  group('FDv1 fallback header on connect', () {
+  group('FDv1 fallback directive', () {
     test(
-        'x-ld-fd-fallback: true on the OpenEvent emits terminalError and '
-        'closes', () async {
+        'a directive on a successful connection is emitted with the basis '
+        'change set so the payload is applied before fallback', () async {
       final sse = makeSse();
       final base = makeBase(sse);
       final emissions = <FDv2SourceResult>[];
-      final done = Completer<void>();
-      base.results.listen(emissions.add, onDone: done.complete);
+      final sub = base.results.listen(emissions.add);
       await Future<void>.delayed(Duration.zero);
 
       emitOpen(sse, headers: {'x-ld-fd-fallback': 'true'});
-      await done.future;
+      emitFullPayload(sse);
+      await Future<void>.delayed(Duration.zero);
 
-      expect(emissions, hasLength(1));
-      final status = emissions.single as StatusResult;
-      expect(status.state, equals(SourceState.terminalError));
-      expect(status.fdv1Fallback, isTrue);
-      expect(sse.isClosed, isTrue);
+      // The basis is delivered as a change set carrying the directive --
+      // not dropped in favor of an immediate terminal error.
+      expect(emissions.single, isA<ChangeSetResult>());
+      final changeSet = emissions.single as ChangeSetResult;
+      expect(changeSet.fdv1Fallback, isTrue);
+      expect(changeSet.changeSet.type, PayloadType.full);
+      // The source stays open; the orchestrator tears it down when it
+      // engages the fallback tier.
+      expect(sse.isClosed, isFalse);
+
+      await sub.cancel();
+    });
+
+    test('the directive carries the fallback TTL from the response header',
+        () async {
+      final sse = makeSse();
+      final base = makeBase(sse);
+      final emissions = <FDv2SourceResult>[];
+      final sub = base.results.listen(emissions.add);
+      await Future<void>.delayed(Duration.zero);
+
+      emitOpen(sse, headers: {
+        'x-ld-fd-fallback': 'true',
+        'x-ld-fd-fallback-ttl': '90',
+      });
+      emitFullPayload(sse);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emissions.single.fdv1FallbackTtl,
+          equals(const Duration(seconds: 90)));
+
+      await sub.cancel();
     });
 
     test('fallback header is matched case-insensitively', () async {
@@ -509,9 +540,10 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       emitOpen(sse, headers: {'x-ld-fd-fallback': 'TRUE'});
+      emitFullPayload(sse);
       await Future<void>.delayed(Duration.zero);
 
-      expect((emissions.single as StatusResult).fdv1Fallback, isTrue);
+      expect(emissions.single.fdv1Fallback, isTrue);
 
       await sub.cancel();
     });
@@ -531,6 +563,116 @@ void main() {
       expect(emissions.single.fdv1Fallback, isFalse);
 
       await sub.cancel();
+    });
+
+    test(
+        'a goodbye carrying protocolFallbackTTL surfaces as a terminal '
+        'fallback directive with that TTL', () async {
+      final sse = makeSse();
+      final base = makeBase(sse);
+      final emissions = <FDv2SourceResult>[];
+      final done = Completer<void>();
+      base.results.listen(emissions.add, onDone: done.complete);
+      await Future<void>.delayed(Duration.zero);
+
+      emitOpen(sse);
+      emitMessage(sse, 'goodbye',
+          jsonEncode({'reason': 'see ya', 'protocolFallbackTTL': 0}));
+      await done.future;
+
+      final status = emissions.single as StatusResult;
+      expect(status.state, SourceState.terminalError);
+      expect(status.fdv1Fallback, isTrue);
+      // A zero TTL means remain on the fallback indefinitely.
+      expect(status.fdv1FallbackTtl, Duration.zero);
+      expect(sse.isClosed, isTrue);
+    });
+
+    test('a goodbye with no protocolFallbackTTL is an ordinary disconnect',
+        () async {
+      final sse = makeSse();
+      final base = makeBase(sse);
+      final emissions = <FDv2SourceResult>[];
+      final done = Completer<void>();
+      base.results.listen(emissions.add, onDone: done.complete);
+      await Future<void>.delayed(Duration.zero);
+
+      emitOpen(sse);
+      emitMessage(sse, 'goodbye', jsonEncode({'reason': 'see ya'}));
+      await done.future;
+
+      final status = emissions.single as StatusResult;
+      expect(status.state, SourceState.goodbye);
+      expect(status.fdv1Fallback, isFalse);
+    });
+  });
+
+  group('SSE HTTP errors', () {
+    test('a recoverable error is interrupted and keeps the source open',
+        () async {
+      final sse = makeSse();
+      final base = makeBase(sse);
+      final emissions = <FDv2SourceResult>[];
+      final sub = base.results.listen(emissions.add);
+      await Future<void>.delayed(Duration.zero);
+
+      sse.emitError(error: SseHttpError(503, const {}, recoverable: true));
+      await Future<void>.delayed(Duration.zero);
+
+      final status = emissions.single as StatusResult;
+      expect(status.state, SourceState.interrupted);
+      expect(status.statusCode, 503);
+      expect(status.fdv1Fallback, isFalse);
+      expect(sse.isClosed, isFalse,
+          reason: 'the client retries a recoverable error on its own');
+
+      await sub.cancel();
+    });
+
+    test('an unrecoverable error is terminal and closes the source', () async {
+      final sse = makeSse();
+      final base = makeBase(sse);
+      final emissions = <FDv2SourceResult>[];
+      final done = Completer<void>();
+      base.results.listen(emissions.add, onDone: done.complete);
+      await Future<void>.delayed(Duration.zero);
+
+      sse.emitError(error: SseHttpError(401, const {}, recoverable: false));
+      await done.future;
+
+      final status = emissions.single as StatusResult;
+      expect(status.state, SourceState.terminalError);
+      expect(status.statusCode, 401);
+      expect(status.fdv1Fallback, isFalse);
+      expect(sse.isClosed, isTrue);
+    });
+
+    test(
+        'a directive on an error response is terminal with the fallback TTL, '
+        'even when the status is recoverable', () async {
+      final sse = makeSse();
+      final base = makeBase(sse);
+      final emissions = <FDv2SourceResult>[];
+      final done = Completer<void>();
+      base.results.listen(emissions.add, onDone: done.complete);
+      await Future<void>.delayed(Duration.zero);
+
+      sse.emitError(
+          error: SseHttpError(
+              503,
+              const {
+                'x-ld-fd-fallback': 'true',
+                'x-ld-fd-fallback-ttl': '120',
+              },
+              recoverable: true));
+      await done.future;
+
+      final status = emissions.single as StatusResult;
+      expect(status.state, SourceState.terminalError);
+      expect(status.fdv1Fallback, isTrue);
+      expect(status.fdv1FallbackTtl, const Duration(seconds: 120));
+      expect(sse.isClosed, isTrue,
+          reason: 'falling back stops the connection regardless of retry');
     });
   });
 

--- a/packages/common_client/test/data_sources/fdv2/streaming_base_test.dart
+++ b/packages/common_client/test/data_sources/fdv2/streaming_base_test.dart
@@ -605,6 +605,33 @@ void main() {
       expect(status.state, SourceState.goodbye);
       expect(status.fdv1Fallback, isFalse);
     });
+
+    test(
+        'a goodbye after a header directive (no payload) surfaces as a '
+        'terminal fallback, carrying the header TTL', () async {
+      final sse = makeSse();
+      final base = makeBase(sse);
+      final emissions = <FDv2SourceResult>[];
+      final done = Completer<void>();
+      base.results.listen(emissions.add, onDone: done.complete);
+      await Future<void>.delayed(Duration.zero);
+
+      // The connection opened with the directive header, then the server
+      // said goodbye before any payload consumed the pending directive.
+      emitOpen(sse, headers: {
+        'x-ld-fd-fallback': 'true',
+        'x-ld-fd-fallback-ttl': '45',
+      });
+      emitMessage(sse, 'goodbye', jsonEncode({'reason': 'see ya'}));
+      await done.future;
+
+      final status = emissions.single as StatusResult;
+      expect(status.state, SourceState.terminalError);
+      expect(status.fdv1Fallback, isTrue,
+          reason: 'the header directive must not be dropped on goodbye');
+      expect(status.fdv1FallbackTtl, const Duration(seconds: 45));
+      expect(sse.isClosed, isTrue);
+    });
   });
 
   group('SSE HTTP errors', () {


### PR DESCRIPTION
Stacked on #311 (the `SseHttpError` surfacing this depends on).

## What

Honors the FDv1 fallback directive across every way the server can deliver it:

- **Successful connection:** the directive is emitted with the basis change set, so the streamed payload is applied *before* the SDK falls back — previously the basis was dropped the moment the header was seen.
- **Any error response carrying the header** (`SseHttpError`, recoverable or not): the streaming source closes the connection — which stops the client's own retry — and routes to the fallback tier.
- **`goodbye` event with `protocolFallbackTTL`:** treated as an in-band fallback directive, for transports that cannot read response headers.

A single helper parses the directive (presence + TTL) from response headers, used for both the successful and error paths; the goodbye path reads its TTL in-band.

The streaming source maps `SseHttpError` by its `recoverable` flag: recoverable → interrupted (the client retries), unrecoverable → terminal. The FDv1 streaming source ignores recoverable errors so a transient 5xx no longer shuts it down.

When a fallback tier is configured the orchestrator engages it. When none is configured, the SDK stays interrupted and retries FDv2 after the directive's TTL (default 1 hour; a TTL of `0` means remain paused with no retry) rather than halting or reconnecting immediately. Source results carry the fallback TTL.

## Tests

- Orchestrator: apply-then-engage from a directive-bearing change set, and the three no-fallback cases (finite TTL retries, absent TTL defers, zero TTL pauses).
- `streaming_base`: defer-on-success, the TTL header, the goodbye/TTL directive, and the `SseHttpError` paths (recoverable → interrupted/stays open, unrecoverable → terminal/closes, directive → terminal+TTL regardless of recoverability). `protocol_handler` covers `protocolFallbackTTL` parsing.
- v3 contract harness `fdv1-fallback` suite passes end-to-end (816 total, 792 ran, exit 0), with no regression.

The contract-test-service capability + `fdv1Fallback` config wiring that exercises this in the harness lives on the e2e branch and will land with the v3 contract-tests PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core FDv2 connection lifecycle, tier selection, and flag delivery ordering when servers send fallback signals; behavior shifts are broad but covered by new unit/contract tests.
> 
> **Overview**
> Implements end-to-end handling when the server asks the SDK to fall back from FDv2 to FDv1, including **TTL-aware retry** when no FDv1 tier is configured.
> 
> **Directive parsing and propagation:** Adds shared `readFallbackDirective` for `x-ld-fd-fallback` / `x-ld-fd-fallback-ttl`, threads `fdv1FallbackTtl` through `FDv2SourceResult`, and parses in-band `protocolFallbackTTL` on goodbye events.
> 
> **Streaming / polling behavior:** On a **successful** stream open, the directive is **deferred** and emitted with the next change set so the basis payload is applied before fallback (replacing immediate terminal error on connect). **HTTP errors** with the header, and **goodbye** with TTL or a pending header, surface as terminal fallback results so the orchestrator does not recycle past the directive. Polling mirrors goodbye/header TTL stamping. FDv2 streaming maps `SseHttpError` by recoverability; legacy FDv1 streaming **ignores recoverable** SSE HTTP errors so transient 5xx no longer shuts the source down.
> 
> **Orchestrator:** Classifies directives into engage FDv1 tier, defer retry (no tier: wait TTL—default 1h, zero = pause indefinitely), or none; schedules recycle via `_pendingRetryDelay` and interruptible `_delay` on stop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74e7c4bb1f2042178e2bb13f7ad2156ee96a2993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->