### PR TITLE
test: exercise FDv2 and FDv1 fallback via the v3 contract tests

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -63,7 +63,7 @@ runs:
         cd packages/common
         dart test test/serialization/canonicalize_json_platform_test.dart -p chrome --test-randomize-ordering-seed=random
 
-    - name: Contract Tests
+    - name: Contract Tests (FDv1)
       shell: bash
       run: |
         pushd apps/flutter_client_contract_test_service
@@ -72,6 +72,22 @@ runs:
       with:
         test_service_port: 8080
         token: ${{ inputs.github_token }}
+        enable_persistence_tests: false
+        extra_params: '-status-timeout 100 --skip-from=./apps/flutter_client_contract_test_service/testharness-suppressions.txt'
+
+    # FDv2 contract tests run against the v3 harness. The FDv1 run above
+    # stops the test service when it finishes, so start it again here.
+    - name: Contract Tests (FDv2)
+      shell: bash
+      run: |
+        pushd apps/flutter_client_contract_test_service
+        flutter test bin/contract_test_service.dart > test-service-fdv2.log 2>&1 & disown
+    - uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1.3.0
+      with:
+        test_service_port: 8080
+        token: ${{ inputs.github_token }}
+        version: 'v3'
+        branch: 'v3'
         enable_persistence_tests: false
         extra_params: '-status-timeout 100 --skip-from=./apps/flutter_client_contract_test_service/testharness-suppressions.txt'
 

--- a/apps/flutter_client_contract_test_service/bin/contract_test_service.dart
+++ b/apps/flutter_client_contract_test_service/bin/contract_test_service.dart
@@ -28,6 +28,8 @@ class TestApiImpl extends SdkTestApi {
     'client-per-context-summaries',
     'client-prereq-events',
     'auto-env-attributes',
+    'client-event-source-http-errors',
+    'fdv1-fallback',
   ];
 
   static const clientUrlPrefix = '/client/';
@@ -50,6 +52,8 @@ class TestApiImpl extends SdkTestApi {
   Future<PostResponse> Post(PostSchema body) async {
     final startWaitTimeMillis =
         body.configuration?.startWaitTimeMs?.toInt() ?? defaultWaitTimeMillis;
+    final mappedDataSystem =
+        _mapDataSystem(body.configuration?.dataSystem?.toJson());
     final config = LDConfig(
       body.configuration?.credential ?? '',
       AutoEnvAttributes.disabled,
@@ -64,9 +68,10 @@ class TestApiImpl extends SdkTestApi {
           streaming: body.configuration?.streaming?.baseUri,
           events: body.configuration?.events?.baseUri),
       dataSourceConfig: DataSourceConfig(
-          initialConnectionMode: body.configuration?.streaming != null
-              ? ConnectionMode.streaming
-              : ConnectionMode.polling,
+          initialConnectionMode: mappedDataSystem?.initialConnectionMode ??
+              (body.configuration?.streaming != null
+                  ? ConnectionMode.streaming
+                  : ConnectionMode.polling),
           evaluationReasons: body.configuration?.clientSide?.evaluationReasons,
           useReport: body.configuration?.clientSide?.useReport),
       events: EventsConfig(
@@ -78,6 +83,7 @@ class TestApiImpl extends SdkTestApi {
           body.configuration?.events?.allAttributesPrivate ?? false,
       globalPrivateAttributes:
           body.configuration?.events?.globalPrivateAttributes,
+      dataSystem: mappedDataSystem?.config,
     );
 
     final configuration = body.configuration!;
@@ -289,6 +295,148 @@ class TestApiImpl extends SdkTestApi {
     return response;
   }
 
+  /// Translates the harness `dataSystem` configuration block into the
+  /// SDK's [DataSystemConfig] and an initial connection mode.
+  ///
+  /// Two shapes are supported, mirroring the harness:
+  /// - `connectionModeConfig` with a map of mode name to mode definition
+  ///   plus `initialConnectionMode`. The SDK overrides built-in modes
+  ///   only, so a definition is applied when its name matches a built-in
+  ///   ([ConnectionModeId]); other names are ignored.
+  /// - Top-level `initializers`/`synchronizers` lists, which override the
+  ///   built-in streaming mode.
+  ({DataSystemConfig config, ConnectionMode initialConnectionMode})?
+      _mapDataSystem(Map<String, dynamic>? raw) {
+    if (raw == null) {
+      return null;
+    }
+
+    // The FDv1 fallback is configured at the data-system level (a polling
+    // config); it applies to whichever modes are built below.
+    Fdv1FallbackConfig? parseFdv1Fallback() {
+      if (raw['fdv1Fallback'] case final Map<String, dynamic> fallback) {
+        return Fdv1FallbackConfig(
+          pollInterval: fallback['pollIntervalMs'] != null
+              ? Duration(
+                  milliseconds: (fallback['pollIntervalMs'] as num).toInt())
+              : null,
+          endpoints: fallback['baseUri'] != null
+              ? EndpointConfig(
+                  pollingBaseUri: Uri.parse(fallback['baseUri'] as String))
+              : null,
+        );
+      }
+      return null;
+    }
+
+    final fdv1Fallback = parseFdv1Fallback();
+
+    ModeDefinition translateMode(Map<String, dynamic> modeJson) {
+      final initializers = <InitializerEntry>[];
+      for (final entry in (modeJson['initializers'] as List<dynamic>? ?? [])) {
+        final initializer = entry as Map<String, dynamic>;
+        if (initializer['polling'] case final Map<String, dynamic> polling) {
+          initializers.add(PollingInitializer(
+              endpoints: EndpointConfig(
+                  pollingBaseUri: polling['baseUri'] != null
+                      ? Uri.parse(polling['baseUri'] as String)
+                      : null)));
+        }
+      }
+
+      final synchronizers = <SynchronizerEntry>[];
+      for (final entry in (modeJson['synchronizers'] as List<dynamic>? ?? [])) {
+        final synchronizer = entry as Map<String, dynamic>;
+        if (synchronizer['streaming']
+            case final Map<String, dynamic> streaming) {
+          synchronizers.add(StreamingSynchronizer(
+              initialReconnectDelay: streaming['initialRetryDelayMs'] != null
+                  ? Duration(
+                      milliseconds:
+                          (streaming['initialRetryDelayMs'] as num).toInt())
+                  : null,
+              endpoints: EndpointConfig(
+                  streamingBaseUri: streaming['baseUri'] != null
+                      ? Uri.parse(streaming['baseUri'] as String)
+                      : null)));
+        } else if (synchronizer['polling']
+            case final Map<String, dynamic> polling) {
+          synchronizers.add(PollingSynchronizer(
+              pollInterval: polling['pollIntervalMs'] != null
+                  ? Duration(
+                      milliseconds: (polling['pollIntervalMs'] as num).toInt())
+                  : null,
+              endpoints: EndpointConfig(
+                  pollingBaseUri: polling['baseUri'] != null
+                      ? Uri.parse(polling['baseUri'] as String)
+                      : null)));
+        }
+      }
+
+      return ModeDefinition(
+          initializers: initializers,
+          synchronizers: synchronizers,
+          fdv1Fallback: fdv1Fallback);
+    }
+
+    ConnectionMode parseInitialMode(String? name) {
+      return switch (name) {
+        'polling' => ConnectionMode.polling,
+        'offline' => ConnectionMode.offline,
+        _ => ConnectionMode.streaming,
+      };
+    }
+
+    ConnectionModeId? builtInModeId(String name) {
+      return switch (name) {
+        'streaming' => ConnectionModeId.streaming,
+        'polling' => ConnectionModeId.polling,
+        'background' => ConnectionModeId.background,
+        'offline' => ConnectionModeId.offline,
+        _ => null,
+      };
+    }
+
+    if (raw['connectionModeConfig'] case final Map<String, dynamic> connMode) {
+      final overrides = <ConnectionModeId, ModeDefinition>{};
+      if (connMode['customConnectionModes']
+          case final Map<String, dynamic> modes) {
+        for (final entry in modes.entries) {
+          if (builtInModeId(entry.key) case final id?) {
+            overrides[id] = translateMode(entry.value as Map<String, dynamic>);
+          }
+        }
+      }
+      final initialModeName = connMode['initialConnectionMode'] as String?;
+      return (
+        config: DataSystemConfig(
+          connectionModes: overrides,
+          // Under the FDv2 data system the initial mode must be carried on
+          // the data system config; the FDv1 initialConnectionMode is inert.
+          initialConnectionMode:
+              initialModeName == null ? null : builtInModeId(initialModeName),
+        ),
+        initialConnectionMode: parseInitialMode(initialModeName),
+      );
+    }
+
+    if (raw['initializers'] != null || raw['synchronizers'] != null) {
+      // Top-level source lists override the built-in streaming mode.
+      return (
+        config: DataSystemConfig(
+            connectionModes: {ConnectionModeId.streaming: translateMode(raw)}),
+        initialConnectionMode: ConnectionMode.streaming,
+      );
+    }
+
+    // Present but empty (or useDefaultDataSystem): FDv2 with built-in
+    // modes.
+    return (
+      config: DataSystemConfig(),
+      initialConnectionMode: ConnectionMode.streaming,
+    );
+  }
+
   LDContext _contextFromSingleOrMulti(SingleOrMultiBuildContext input) {
     if (input.single != null) {
       return _flattenedListToContext(
@@ -315,8 +463,8 @@ class TestApiImpl extends SdkTestApi {
       final multi = input.multi!.toList();
       final builder = common.LDContextBuilder();
       for (var single in multi) {
-        final kind = single['kind'];
-        final key = single['key'];
+        final kind = single['kind'] as String;
+        final key = single['key'] as String?;
 
         final singleAttributesBuilder = builder.kind(kind, key);
         _buildSingleAttributes(singleAttributesBuilder, single.toJson());
@@ -364,7 +512,12 @@ class TestApiImpl extends SdkTestApi {
 
   Response _responseFromEvaluation(LDValue value) {
     final response = Response();
-    response['value'] = common.LDValueSerialization.toJson(value);
+    // A null evaluation result is omitted rather than set: the response
+    // map rejects null values, and an absent key deserializes the same
+    // as an explicit null on the harness side.
+    if (common.LDValueSerialization.toJson(value) case final Object json) {
+      response['value'] = json;
+    }
     return response;
   }
 
@@ -385,7 +538,7 @@ class TestApiImpl extends SdkTestApi {
     if (input['private'] != null) {
       retMap['_meta'] = {'privateAttributes': input['private']};
     }
-    retMap.addAll(input['custom'] ?? {});
+    retMap.addAll(input['custom'] as Map<String, dynamic>? ?? {});
     return retMap;
   }
 
@@ -453,7 +606,7 @@ final class _WifiConnected extends ConnectivityPlatform {
 }
 
 void main() async {
-  test('Run contract tests', () async {
+  test(timeout: Timeout.none, 'Run contract tests', () async {
     ConnectivityPlatform.instance = _WifiConnected();
     widgets.WidgetsFlutterBinding.ensureInitialized(); // needed before mocking
     // ignore: invalid_use_of_visible_for_testing_member

--- a/apps/flutter_client_contract_test_service/bin/service_api.openapi.dart
+++ b/apps/flutter_client_contract_test_service/bin/service_api.openapi.dart
@@ -17,7 +17,7 @@ class RequestIdentifyEventContext implements OpenApiContent {
         .._additionalProperties.addEntries(
             jsonMap.entries.where((e) => !const <String>{}.contains(e.key)));
 
-  final Map<String, dynamic> _additionalProperties = <String, dynamic>{};
+  final Map<String, Object?> _additionalProperties = <String, Object?>{};
 
   Map<String, dynamic> toJson() => Map.from(_additionalProperties)
     ..addAll(_$RequestIdentifyEventContextToJson(this));
@@ -27,11 +27,11 @@ class RequestIdentifyEventContext implements OpenApiContent {
 
   void operator []=(
     String key,
-    dynamic value,
+    Object value,
   ) =>
       _additionalProperties[key] = value;
 
-  dynamic operator [](String key) => _additionalProperties[key];
+  Object? operator [](String key) => _additionalProperties[key];
 }
 
 @JsonSerializable()
@@ -64,7 +64,7 @@ class RequestEvaluateContext implements OpenApiContent {
         .._additionalProperties.addEntries(
             jsonMap.entries.where((e) => !const <String>{}.contains(e.key)));
 
-  final Map<String, dynamic> _additionalProperties = <String, dynamic>{};
+  final Map<String, Object?> _additionalProperties = <String, Object?>{};
 
   Map<String, dynamic> toJson() => Map.from(_additionalProperties)
     ..addAll(_$RequestEvaluateContextToJson(this));
@@ -74,11 +74,11 @@ class RequestEvaluateContext implements OpenApiContent {
 
   void operator []=(
     String key,
-    dynamic value,
+    Object value,
   ) =>
       _additionalProperties[key] = value;
 
-  dynamic operator [](String key) => _additionalProperties[key];
+  Object? operator [](String key) => _additionalProperties[key];
 }
 
 @JsonSerializable()
@@ -91,7 +91,7 @@ class RequestEvaluateUser implements OpenApiContent {
         .._additionalProperties.addEntries(
             jsonMap.entries.where((e) => !const <String>{}.contains(e.key)));
 
-  final Map<String, dynamic> _additionalProperties = <String, dynamic>{};
+  final Map<String, Object?> _additionalProperties = <String, Object?>{};
 
   Map<String, dynamic> toJson() => Map.from(_additionalProperties)
     ..addAll(_$RequestEvaluateUserToJson(this));
@@ -101,11 +101,11 @@ class RequestEvaluateUser implements OpenApiContent {
 
   void operator []=(
     String key,
-    dynamic value,
+    Object value,
   ) =>
       _additionalProperties[key] = value;
 
-  dynamic operator [](String key) => _additionalProperties[key];
+  Object? operator [](String key) => _additionalProperties[key];
 }
 
 @JsonSerializable()
@@ -160,7 +160,7 @@ class RequestEvaluate implements OpenApiContent {
   )
   final bool? detail;
 
-  final Map<String, dynamic> _additionalProperties = <String, dynamic>{};
+  final Map<String, Object?> _additionalProperties = <String, Object?>{};
 
   Map<String, dynamic> toJson() =>
       Map.from(_additionalProperties)..addAll(_$RequestEvaluateToJson(this));
@@ -170,11 +170,11 @@ class RequestEvaluate implements OpenApiContent {
 
   void operator []=(
     String key,
-    dynamic value,
+    Object value,
   ) =>
       _additionalProperties[key] = value;
 
-  dynamic operator [](String key) => _additionalProperties[key];
+  Object? operator [](String key) => _additionalProperties[key];
 }
 
 @JsonSerializable()
@@ -187,7 +187,7 @@ class RequestEvaluateAllContext implements OpenApiContent {
         .._additionalProperties.addEntries(
             jsonMap.entries.where((e) => !const <String>{}.contains(e.key)));
 
-  final Map<String, dynamic> _additionalProperties = <String, dynamic>{};
+  final Map<String, Object?> _additionalProperties = <String, Object?>{};
 
   Map<String, dynamic> toJson() => Map.from(_additionalProperties)
     ..addAll(_$RequestEvaluateAllContextToJson(this));
@@ -197,11 +197,11 @@ class RequestEvaluateAllContext implements OpenApiContent {
 
   void operator []=(
     String key,
-    dynamic value,
+    Object value,
   ) =>
       _additionalProperties[key] = value;
 
-  dynamic operator [](String key) => _additionalProperties[key];
+  Object? operator [](String key) => _additionalProperties[key];
 }
 
 @JsonSerializable()
@@ -214,7 +214,7 @@ class RequestEvaluateAllUser implements OpenApiContent {
         .._additionalProperties.addEntries(
             jsonMap.entries.where((e) => !const <String>{}.contains(e.key)));
 
-  final Map<String, dynamic> _additionalProperties = <String, dynamic>{};
+  final Map<String, Object?> _additionalProperties = <String, Object?>{};
 
   Map<String, dynamic> toJson() => Map.from(_additionalProperties)
     ..addAll(_$RequestEvaluateAllUserToJson(this));
@@ -224,11 +224,11 @@ class RequestEvaluateAllUser implements OpenApiContent {
 
   void operator []=(
     String key,
-    dynamic value,
+    Object value,
   ) =>
       _additionalProperties[key] = value;
 
-  dynamic operator [](String key) => _additionalProperties[key];
+  Object? operator [](String key) => _additionalProperties[key];
 }
 
 @JsonSerializable()
@@ -317,7 +317,7 @@ class RequestCustomEvent implements OpenApiContent {
   )
   final num? metricValue;
 
-  final Map<String, dynamic> _additionalProperties = <String, dynamic>{};
+  final Map<String, Object?> _additionalProperties = <String, Object?>{};
 
   Map<String, dynamic> toJson() =>
       Map.from(_additionalProperties)..addAll(_$RequestCustomEventToJson(this));
@@ -327,11 +327,11 @@ class RequestCustomEvent implements OpenApiContent {
 
   void operator []=(
     String key,
-    dynamic value,
+    Object value,
   ) =>
       _additionalProperties[key] = value;
 
-  dynamic operator [](String key) => _additionalProperties[key];
+  Object? operator [](String key) => _additionalProperties[key];
 }
 
 @JsonSerializable()
@@ -344,7 +344,7 @@ class BuildContext implements OpenApiContent {
         .._additionalProperties.addEntries(
             jsonMap.entries.where((e) => !const <String>{}.contains(e.key)));
 
-  final Map<String, dynamic> _additionalProperties = <String, dynamic>{};
+  final Map<String, Object?> _additionalProperties = <String, Object?>{};
 
   Map<String, dynamic> toJson() =>
       Map.from(_additionalProperties)..addAll(_$BuildContextToJson(this));
@@ -354,11 +354,11 @@ class BuildContext implements OpenApiContent {
 
   void operator []=(
     String key,
-    dynamic value,
+    Object value,
   ) =>
       _additionalProperties[key] = value;
 
-  dynamic operator [](String key) => _additionalProperties[key];
+  Object? operator [](String key) => _additionalProperties[key];
 }
 
 @JsonSerializable()
@@ -520,7 +520,7 @@ class Response implements OpenApiContent {
         .._additionalProperties.addEntries(
             jsonMap.entries.where((e) => !const <String>{}.contains(e.key)));
 
-  final Map<String, dynamic> _additionalProperties = <String, dynamic>{};
+  final Map<String, Object?> _additionalProperties = <String, Object?>{};
 
   Map<String, dynamic> toJson() =>
       Map.from(_additionalProperties)..addAll(_$ResponseToJson(this));
@@ -530,11 +530,11 @@ class Response implements OpenApiContent {
 
   void operator []=(
     String key,
-    dynamic value,
+    Object value,
   ) =>
       _additionalProperties[key] = value;
 
-  dynamic operator [](String key) => _additionalProperties[key];
+  Object? operator [](String key) => _additionalProperties[key];
 }
 
 @JsonSerializable()
@@ -592,7 +592,7 @@ class GetResponse200 extends GetResponse implements OpenApiResponseBodyJson {
       OpenApiContentType.parse('application/json');
 
   @override
-  Map<String, dynamic> propertiesToString() => {
+  Map<String, Object?> propertiesToString() => {
         'status': status,
         'body': body,
         'bodyJson': bodyJson,
@@ -643,7 +643,7 @@ class PostResponse201 extends PostResponse {
   final OpenApiContentType? contentType = null;
 
   @override
-  Map<String, dynamic> propertiesToString() => {
+  Map<String, Object?> propertiesToString() => {
         'status': status,
         'contentType': contentType,
       };
@@ -660,7 +660,7 @@ class PostResponse400 extends PostResponse {
   final OpenApiContentType? contentType = null;
 
   @override
-  Map<String, dynamic> propertiesToString() => {
+  Map<String, Object?> propertiesToString() => {
         'status': status,
         'contentType': contentType,
       };
@@ -973,7 +973,7 @@ class PostSchemaConfigurationClientSideInitialContext
         .._additionalProperties.addEntries(
             jsonMap.entries.where((e) => !const <String>{}.contains(e.key)));
 
-  final Map<String, dynamic> _additionalProperties = <String, dynamic>{};
+  final Map<String, Object?> _additionalProperties = <String, Object?>{};
 
   Map<String, dynamic> toJson() => Map.from(_additionalProperties)
     ..addAll(_$PostSchemaConfigurationClientSideInitialContextToJson(this));
@@ -983,11 +983,11 @@ class PostSchemaConfigurationClientSideInitialContext
 
   void operator []=(
     String key,
-    dynamic value,
+    Object value,
   ) =>
       _additionalProperties[key] = value;
 
-  dynamic operator [](String key) => _additionalProperties[key];
+  Object? operator [](String key) => _additionalProperties[key];
 }
 
 @JsonSerializable()
@@ -1001,7 +1001,7 @@ class PostSchemaConfigurationClientSideInitialUser implements OpenApiContent {
         .._additionalProperties.addEntries(
             jsonMap.entries.where((e) => !const <String>{}.contains(e.key)));
 
-  final Map<String, dynamic> _additionalProperties = <String, dynamic>{};
+  final Map<String, Object?> _additionalProperties = <String, Object?>{};
 
   Map<String, dynamic> toJson() => Map.from(_additionalProperties)
     ..addAll(_$PostSchemaConfigurationClientSideInitialUserToJson(this));
@@ -1011,11 +1011,11 @@ class PostSchemaConfigurationClientSideInitialUser implements OpenApiContent {
 
   void operator []=(
     String key,
-    dynamic value,
+    Object value,
   ) =>
       _additionalProperties[key] = value;
 
-  dynamic operator [](String key) => _additionalProperties[key];
+  Object? operator [](String key) => _additionalProperties[key];
 }
 
 @JsonSerializable()
@@ -1063,6 +1063,35 @@ class PostSchemaConfigurationClientSide implements OpenApiContent {
   String toString() => toJson().toString();
 }
 
+/// FDv2 data system configuration.
+@JsonSerializable()
+@ApiUuidJsonConverter()
+class PostSchemaConfigurationDataSystem implements OpenApiContent {
+  PostSchemaConfigurationDataSystem();
+
+  factory PostSchemaConfigurationDataSystem.fromJson(
+          Map<String, dynamic> jsonMap) =>
+      _$PostSchemaConfigurationDataSystemFromJson(jsonMap)
+        .._additionalProperties.addEntries(
+            jsonMap.entries.where((e) => !const <String>{}.contains(e.key)));
+
+  final Map<String, Object?> _additionalProperties = <String, Object?>{};
+
+  Map<String, dynamic> toJson() => Map.from(_additionalProperties)
+    ..addAll(_$PostSchemaConfigurationDataSystemToJson(this));
+
+  @override
+  String toString() => toJson().toString();
+
+  void operator []=(
+    String key,
+    Object value,
+  ) =>
+      _additionalProperties[key] = value;
+
+  Object? operator [](String key) => _additionalProperties[key];
+}
+
 @JsonSerializable()
 @ApiUuidJsonConverter()
 class PostSchemaConfiguration implements OpenApiContent {
@@ -1077,6 +1106,7 @@ class PostSchemaConfiguration implements OpenApiContent {
     this.bigSegments,
     this.tags,
     this.clientSide,
+    this.dataSystem,
   });
 
   factory PostSchemaConfiguration.fromJson(Map<String, dynamic> jsonMap) =>
@@ -1145,6 +1175,13 @@ class PostSchemaConfiguration implements OpenApiContent {
   )
   final PostSchemaConfigurationClientSide? clientSide;
 
+  /// FDv2 data system configuration.
+  @JsonKey(
+    name: 'dataSystem',
+    includeIfNull: false,
+  )
+  final PostSchemaConfigurationDataSystem? dataSystem;
+
   Map<String, dynamic> toJson() => _$PostSchemaConfigurationToJson(this);
 
   @override
@@ -1191,7 +1228,7 @@ class DeleteResponse200 extends DeleteResponse {
   final OpenApiContentType? contentType = null;
 
   @override
-  Map<String, dynamic> propertiesToString() => {
+  Map<String, Object?> propertiesToString() => {
         'status': status,
         'contentType': contentType,
       };
@@ -1248,7 +1285,7 @@ class ClientIdPostResponse200 extends ClientIdPostResponse
       OpenApiContentType.parse('application/json');
 
   @override
-  Map<String, dynamic> propertiesToString() => {
+  Map<String, Object?> propertiesToString() => {
         'status': status,
         'body': body,
         'bodyJson': bodyJson,
@@ -1267,7 +1304,7 @@ class ClientIdPostResponse404 extends ClientIdPostResponse {
   final OpenApiContentType? contentType = null;
 
   @override
-  Map<String, dynamic> propertiesToString() => {
+  Map<String, Object?> propertiesToString() => {
         'status': status,
         'contentType': contentType,
       };
@@ -1323,7 +1360,7 @@ class ClientIdDeleteResponse200 extends ClientIdDeleteResponse {
   final OpenApiContentType? contentType = null;
 
   @override
-  Map<String, dynamic> propertiesToString() => {
+  Map<String, Object?> propertiesToString() => {
         'status': status,
         'contentType': contentType,
       };
@@ -1340,7 +1377,7 @@ class ClientIdDeleteResponse404 extends ClientIdDeleteResponse {
   final OpenApiContentType? contentType = null;
 
   @override
-  Map<String, dynamic> propertiesToString() => {
+  Map<String, Object?> propertiesToString() => {
         'status': status,
         'contentType': contentType,
       };

--- a/apps/flutter_client_contract_test_service/bin/service_api.openapi.g.dart
+++ b/apps/flutter_client_contract_test_service/bin/service_api.openapi.g.dart
@@ -24,10 +24,18 @@ RequestIdentifyEvent _$RequestIdentifyEventFromJson(
     );
 
 Map<String, dynamic> _$RequestIdentifyEventToJson(
-        RequestIdentifyEvent instance) =>
-    <String, dynamic>{
-      if (instance.context case final value?) 'context': value,
-    };
+    RequestIdentifyEvent instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('context', instance.context);
+  return val;
+}
 
 RequestEvaluateContext _$RequestEvaluateContextFromJson(
         Map<String, dynamic> json) =>
@@ -58,14 +66,22 @@ RequestEvaluate _$RequestEvaluateFromJson(Map<String, dynamic> json) =>
       detail: json['detail'] as bool?,
     );
 
-Map<String, dynamic> _$RequestEvaluateToJson(RequestEvaluate instance) =>
-    <String, dynamic>{
-      if (instance.flagKey case final value?) 'flagKey': value,
-      if (instance.context case final value?) 'context': value,
-      if (instance.user case final value?) 'user': value,
-      if (instance.valueType case final value?) 'valueType': value,
-      if (instance.detail case final value?) 'detail': value,
-    };
+Map<String, dynamic> _$RequestEvaluateToJson(RequestEvaluate instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('flagKey', instance.flagKey);
+  writeNotNull('context', instance.context);
+  writeNotNull('user', instance.user);
+  writeNotNull('valueType', instance.valueType);
+  writeNotNull('detail', instance.detail);
+  return val;
+}
 
 RequestEvaluateAllContext _$RequestEvaluateAllContextFromJson(
         Map<String, dynamic> json) =>
@@ -98,15 +114,23 @@ RequestEvaluateAll _$RequestEvaluateAllFromJson(Map<String, dynamic> json) =>
       detailsOnlyForTrackedFlags: json['detailsOnlyForTrackedFlags'] as bool?,
     );
 
-Map<String, dynamic> _$RequestEvaluateAllToJson(RequestEvaluateAll instance) =>
-    <String, dynamic>{
-      if (instance.context case final value?) 'context': value,
-      if (instance.user case final value?) 'user': value,
-      if (instance.withReasons case final value?) 'withReasons': value,
-      if (instance.clientSideOnly case final value?) 'clientSideOnly': value,
-      if (instance.detailsOnlyForTrackedFlags case final value?)
-        'detailsOnlyForTrackedFlags': value,
-    };
+Map<String, dynamic> _$RequestEvaluateAllToJson(RequestEvaluateAll instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('context', instance.context);
+  writeNotNull('user', instance.user);
+  writeNotNull('withReasons', instance.withReasons);
+  writeNotNull('clientSideOnly', instance.clientSideOnly);
+  writeNotNull(
+      'detailsOnlyForTrackedFlags', instance.detailsOnlyForTrackedFlags);
+  return val;
+}
 
 RequestCustomEvent _$RequestCustomEventFromJson(Map<String, dynamic> json) =>
     RequestCustomEvent(
@@ -115,12 +139,20 @@ RequestCustomEvent _$RequestCustomEventFromJson(Map<String, dynamic> json) =>
       metricValue: json['metricValue'] as num?,
     );
 
-Map<String, dynamic> _$RequestCustomEventToJson(RequestCustomEvent instance) =>
-    <String, dynamic>{
-      if (instance.eventKey case final value?) 'eventKey': value,
-      if (instance.omitNullData case final value?) 'omitNullData': value,
-      if (instance.metricValue case final value?) 'metricValue': value,
-    };
+Map<String, dynamic> _$RequestCustomEventToJson(RequestCustomEvent instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('eventKey', instance.eventKey);
+  writeNotNull('omitNullData', instance.omitNullData);
+  writeNotNull('metricValue', instance.metricValue);
+  return val;
+}
 
 BuildContext _$BuildContextFromJson(Map<String, dynamic> json) =>
     BuildContext();
@@ -140,11 +172,19 @@ SingleOrMultiBuildContext _$SingleOrMultiBuildContextFromJson(
     );
 
 Map<String, dynamic> _$SingleOrMultiBuildContextToJson(
-        SingleOrMultiBuildContext instance) =>
-    <String, dynamic>{
-      if (instance.single case final value?) 'single': value,
-      if (instance.multi case final value?) 'multi': value,
-    };
+    SingleOrMultiBuildContext instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('single', instance.single);
+  writeNotNull('multi', instance.multi);
+  return val;
+}
 
 RequestContextConvert _$RequestContextConvertFromJson(
         Map<String, dynamic> json) =>
@@ -153,10 +193,18 @@ RequestContextConvert _$RequestContextConvertFromJson(
     );
 
 Map<String, dynamic> _$RequestContextConvertToJson(
-        RequestContextConvert instance) =>
-    <String, dynamic>{
-      if (instance.input case final value?) 'input': value,
-    };
+    RequestContextConvert instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('input', instance.input);
+  return val;
+}
 
 RequestContextComparison _$RequestContextComparisonFromJson(
         Map<String, dynamic> json) =>
@@ -172,11 +220,19 @@ RequestContextComparison _$RequestContextComparisonFromJson(
     );
 
 Map<String, dynamic> _$RequestContextComparisonToJson(
-        RequestContextComparison instance) =>
-    <String, dynamic>{
-      if (instance.context1 case final value?) 'context1': value,
-      if (instance.context2 case final value?) 'context2': value,
-    };
+    RequestContextComparison instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('context1', instance.context1);
+  writeNotNull('context2', instance.context2);
+  return val;
+}
 
 Request _$RequestFromJson(Map<String, dynamic> json) => Request(
       command: json['command'] as String?,
@@ -209,17 +265,25 @@ Request _$RequestFromJson(Map<String, dynamic> json) => Request(
               json['contextComparison'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$RequestToJson(Request instance) => <String, dynamic>{
-      if (instance.command case final value?) 'command': value,
-      if (instance.identifyEvent case final value?) 'identifyEvent': value,
-      if (instance.evaluate case final value?) 'evaluate': value,
-      if (instance.evaluateAll case final value?) 'evaluateAll': value,
-      if (instance.customEvent case final value?) 'customEvent': value,
-      if (instance.contextBuild case final value?) 'contextBuild': value,
-      if (instance.contextConvert case final value?) 'contextConvert': value,
-      if (instance.contextComparison case final value?)
-        'contextComparison': value,
-    };
+Map<String, dynamic> _$RequestToJson(Request instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('command', instance.command);
+  writeNotNull('identifyEvent', instance.identifyEvent);
+  writeNotNull('evaluate', instance.evaluate);
+  writeNotNull('evaluateAll', instance.evaluateAll);
+  writeNotNull('customEvent', instance.customEvent);
+  writeNotNull('contextBuild', instance.contextBuild);
+  writeNotNull('contextConvert', instance.contextConvert);
+  writeNotNull('contextComparison', instance.contextComparison);
+  return val;
+}
 
 Response _$ResponseFromJson(Map<String, dynamic> json) => Response();
 
@@ -234,12 +298,20 @@ GetResponseBody200 _$GetResponseBody200FromJson(Map<String, dynamic> json) =>
           .toList(),
     );
 
-Map<String, dynamic> _$GetResponseBody200ToJson(GetResponseBody200 instance) =>
-    <String, dynamic>{
-      if (instance.name case final value?) 'name': value,
-      if (instance.clientVersion case final value?) 'clientVersion': value,
-      if (instance.capabilities case final value?) 'capabilities': value,
-    };
+Map<String, dynamic> _$GetResponseBody200ToJson(GetResponseBody200 instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('name', instance.name);
+  writeNotNull('clientVersion', instance.clientVersion);
+  writeNotNull('capabilities', instance.capabilities);
+  return val;
+}
 
 PostSchemaConfigurationServiceEndpoints
     _$PostSchemaConfigurationServiceEndpointsFromJson(
@@ -251,12 +323,20 @@ PostSchemaConfigurationServiceEndpoints
         );
 
 Map<String, dynamic> _$PostSchemaConfigurationServiceEndpointsToJson(
-        PostSchemaConfigurationServiceEndpoints instance) =>
-    <String, dynamic>{
-      if (instance.streaming case final value?) 'streaming': value,
-      if (instance.polling case final value?) 'polling': value,
-      if (instance.events case final value?) 'events': value,
-    };
+    PostSchemaConfigurationServiceEndpoints instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('streaming', instance.streaming);
+  writeNotNull('polling', instance.polling);
+  writeNotNull('events', instance.events);
+  return val;
+}
 
 PostSchemaConfigurationStreaming _$PostSchemaConfigurationStreamingFromJson(
         Map<String, dynamic> json) =>
@@ -267,13 +347,20 @@ PostSchemaConfigurationStreaming _$PostSchemaConfigurationStreamingFromJson(
     );
 
 Map<String, dynamic> _$PostSchemaConfigurationStreamingToJson(
-        PostSchemaConfigurationStreaming instance) =>
-    <String, dynamic>{
-      if (instance.baseUri case final value?) 'baseUri': value,
-      if (instance.initialRetryDelayMs case final value?)
-        'initialRetryDelayMs': value,
-      if (instance.filter case final value?) 'filter': value,
-    };
+    PostSchemaConfigurationStreaming instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('baseUri', instance.baseUri);
+  writeNotNull('initialRetryDelayMs', instance.initialRetryDelayMs);
+  writeNotNull('filter', instance.filter);
+  return val;
+}
 
 PostSchemaConfigurationPolling _$PostSchemaConfigurationPollingFromJson(
         Map<String, dynamic> json) =>
@@ -284,12 +371,20 @@ PostSchemaConfigurationPolling _$PostSchemaConfigurationPollingFromJson(
     );
 
 Map<String, dynamic> _$PostSchemaConfigurationPollingToJson(
-        PostSchemaConfigurationPolling instance) =>
-    <String, dynamic>{
-      if (instance.baseUri case final value?) 'baseUri': value,
-      if (instance.pollIntervalMs case final value?) 'pollIntervalMs': value,
-      if (instance.filter case final value?) 'filter': value,
-    };
+    PostSchemaConfigurationPolling instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('baseUri', instance.baseUri);
+  writeNotNull('pollIntervalMs', instance.pollIntervalMs);
+  writeNotNull('filter', instance.filter);
+  return val;
+}
 
 PostSchemaConfigurationEvents _$PostSchemaConfigurationEventsFromJson(
         Map<String, dynamic> json) =>
@@ -306,18 +401,23 @@ PostSchemaConfigurationEvents _$PostSchemaConfigurationEventsFromJson(
     );
 
 Map<String, dynamic> _$PostSchemaConfigurationEventsToJson(
-        PostSchemaConfigurationEvents instance) =>
-    <String, dynamic>{
-      if (instance.baseUri case final value?) 'baseUri': value,
-      if (instance.capacity case final value?) 'capacity': value,
-      if (instance.enableDiagnostics case final value?)
-        'enableDiagnostics': value,
-      if (instance.allAttributesPrivate case final value?)
-        'allAttributesPrivate': value,
-      if (instance.globalPrivateAttributes case final value?)
-        'globalPrivateAttributes': value,
-      if (instance.flushIntervalMs case final value?) 'flushIntervalMs': value,
-    };
+    PostSchemaConfigurationEvents instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('baseUri', instance.baseUri);
+  writeNotNull('capacity', instance.capacity);
+  writeNotNull('enableDiagnostics', instance.enableDiagnostics);
+  writeNotNull('allAttributesPrivate', instance.allAttributesPrivate);
+  writeNotNull('globalPrivateAttributes', instance.globalPrivateAttributes);
+  writeNotNull('flushIntervalMs', instance.flushIntervalMs);
+  return val;
+}
 
 PostSchemaConfigurationBigSegments _$PostSchemaConfigurationBigSegmentsFromJson(
         Map<String, dynamic> json) =>
@@ -330,15 +430,22 @@ PostSchemaConfigurationBigSegments _$PostSchemaConfigurationBigSegmentsFromJson(
     );
 
 Map<String, dynamic> _$PostSchemaConfigurationBigSegmentsToJson(
-        PostSchemaConfigurationBigSegments instance) =>
-    <String, dynamic>{
-      if (instance.callbackUri case final value?) 'callbackUri': value,
-      if (instance.userCacheSize case final value?) 'userCacheSize': value,
-      if (instance.userCacheTimeMs case final value?) 'userCacheTimeMs': value,
-      if (instance.statusPollIntervalMS case final value?)
-        'statusPollIntervalMS': value,
-      if (instance.staleAfterMs case final value?) 'staleAfterMs': value,
-    };
+    PostSchemaConfigurationBigSegments instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('callbackUri', instance.callbackUri);
+  writeNotNull('userCacheSize', instance.userCacheSize);
+  writeNotNull('userCacheTimeMs', instance.userCacheTimeMs);
+  writeNotNull('statusPollIntervalMS', instance.statusPollIntervalMS);
+  writeNotNull('staleAfterMs', instance.staleAfterMs);
+  return val;
+}
 
 PostSchemaConfigurationTags _$PostSchemaConfigurationTagsFromJson(
         Map<String, dynamic> json) =>
@@ -348,12 +455,19 @@ PostSchemaConfigurationTags _$PostSchemaConfigurationTagsFromJson(
     );
 
 Map<String, dynamic> _$PostSchemaConfigurationTagsToJson(
-        PostSchemaConfigurationTags instance) =>
-    <String, dynamic>{
-      if (instance.applicationId case final value?) 'applicationId': value,
-      if (instance.applicationVersion case final value?)
-        'applicationVersion': value,
-    };
+    PostSchemaConfigurationTags instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('applicationId', instance.applicationId);
+  writeNotNull('applicationVersion', instance.applicationVersion);
+  return val;
+}
 
 PostSchemaConfigurationClientSideInitialContext
     _$PostSchemaConfigurationClientSideInitialContextFromJson(
@@ -389,14 +503,29 @@ PostSchemaConfigurationClientSide _$PostSchemaConfigurationClientSideFromJson(
     );
 
 Map<String, dynamic> _$PostSchemaConfigurationClientSideToJson(
-        PostSchemaConfigurationClientSide instance) =>
-    <String, dynamic>{
-      if (instance.initialContext case final value?) 'initialContext': value,
-      if (instance.initialUser case final value?) 'initialUser': value,
-      if (instance.evaluationReasons case final value?)
-        'evaluationReasons': value,
-      if (instance.useReport case final value?) 'useReport': value,
-    };
+    PostSchemaConfigurationClientSide instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('initialContext', instance.initialContext);
+  writeNotNull('initialUser', instance.initialUser);
+  writeNotNull('evaluationReasons', instance.evaluationReasons);
+  writeNotNull('useReport', instance.useReport);
+  return val;
+}
+
+PostSchemaConfigurationDataSystem _$PostSchemaConfigurationDataSystemFromJson(
+        Map<String, dynamic> json) =>
+    PostSchemaConfigurationDataSystem();
+
+Map<String, dynamic> _$PostSchemaConfigurationDataSystemToJson(
+        PostSchemaConfigurationDataSystem instance) =>
+    <String, dynamic>{};
 
 PostSchemaConfiguration _$PostSchemaConfigurationFromJson(
         Map<String, dynamic> json) =>
@@ -432,23 +561,35 @@ PostSchemaConfiguration _$PostSchemaConfigurationFromJson(
           ? null
           : PostSchemaConfigurationClientSide.fromJson(
               json['clientSide'] as Map<String, dynamic>),
+      dataSystem: json['dataSystem'] == null
+          ? null
+          : PostSchemaConfigurationDataSystem.fromJson(
+              json['dataSystem'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$PostSchemaConfigurationToJson(
-        PostSchemaConfiguration instance) =>
-    <String, dynamic>{
-      if (instance.credential case final value?) 'credential': value,
-      if (instance.startWaitTimeMs case final value?) 'startWaitTimeMs': value,
-      if (instance.initCanFail case final value?) 'initCanFail': value,
-      if (instance.serviceEndpoints case final value?)
-        'serviceEndpoints': value,
-      if (instance.streaming case final value?) 'streaming': value,
-      if (instance.polling case final value?) 'polling': value,
-      if (instance.events case final value?) 'events': value,
-      if (instance.bigSegments case final value?) 'bigSegments': value,
-      if (instance.tags case final value?) 'tags': value,
-      if (instance.clientSide case final value?) 'clientSide': value,
-    };
+    PostSchemaConfiguration instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('credential', instance.credential);
+  writeNotNull('startWaitTimeMs', instance.startWaitTimeMs);
+  writeNotNull('initCanFail', instance.initCanFail);
+  writeNotNull('serviceEndpoints', instance.serviceEndpoints);
+  writeNotNull('streaming', instance.streaming);
+  writeNotNull('polling', instance.polling);
+  writeNotNull('events', instance.events);
+  writeNotNull('bigSegments', instance.bigSegments);
+  writeNotNull('tags', instance.tags);
+  writeNotNull('clientSide', instance.clientSide);
+  writeNotNull('dataSystem', instance.dataSystem);
+  return val;
+}
 
 PostSchema _$PostSchemaFromJson(Map<String, dynamic> json) => PostSchema(
       tag: json['tag'] as String?,
@@ -458,8 +599,16 @@ PostSchema _$PostSchemaFromJson(Map<String, dynamic> json) => PostSchema(
               json['configuration'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$PostSchemaToJson(PostSchema instance) =>
-    <String, dynamic>{
-      if (instance.tag case final value?) 'tag': value,
-      if (instance.configuration case final value?) 'configuration': value,
-    };
+Map<String, dynamic> _$PostSchemaToJson(PostSchema instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('tag', instance.tag);
+  writeNotNull('configuration', instance.configuration);
+  return val;
+}

--- a/apps/flutter_client_contract_test_service/bin/service_api.openapi.yaml
+++ b/apps/flutter_client_contract_test_service/bin/service_api.openapi.yaml
@@ -134,6 +134,10 @@ paths:
                           type: boolean
                         useReport:
                           type: boolean
+                    dataSystem:
+                      type: object
+                      additionalProperties: true
+                      description: FDv2 data system configuration.
       responses:
         '201':
           description: Successful creation

--- a/apps/flutter_client_contract_test_service/pubspec.lock
+++ b/apps/flutter_client_contract_test_service/pubspec.lock
@@ -393,28 +393,28 @@ packages:
       path: "../../packages/common_client"
       relative: true
     source: path
-    version: "1.9.0"
+    version: "1.13.0"
   launchdarkly_dart_common:
     dependency: "direct overridden"
     description:
       path: "../../packages/common"
       relative: true
     source: path
-    version: "1.8.0"
+    version: "1.8.1"
   launchdarkly_event_source_client:
     dependency: "direct overridden"
     description:
       path: "../../packages/event_source_client"
       relative: true
     source: path
-    version: "2.0.1"
+    version: "2.1.0"
   launchdarkly_flutter_client_sdk:
     dependency: "direct main"
     description:
       path: "../../packages/flutter_client_sdk"
       relative: true
     source: path
-    version: "4.15.0"
+    version: "4.19.0"
   lints:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
Stacked on #314 (the Flutter FDv2 exposure). Wires the Flutter contract test service for the **v3 (FDv2) harness** and runs it in CI, so the data system — including FDv1 fallback — is exercised end-to-end.

## Changes
- **Contract service:** advertise the `fdv1-fallback` capability; map the harness `dataSystem` configuration onto `LDConfig.dataSystem` (including the `fdv1Fallback` polling config); regenerate the service API model (`service_api.openapi.*`) for the `dataSystem` schema.
- **CI (`.github/actions/ci/action.yml`):** add an **FDv2 contract-tests run** (the `launchdarkly/gh-actions/actions/contract-tests` action with `version: v3`, `branch: v3`) alongside the existing FDv1 run. Because the FDv1 run stops the test service at the end, the FDv2 step restarts it. Modeled on cpp-sdks' `contract-tests-fdv2` job.

## Validation
The v3 harness passes end-to-end against this service: **816 total / 792 ran / 24 skipped, exit 0** (run locally against this branch on merged main), including the full FDv1 fallback suite. Contract service analyzes clean.

## Notes for review
The CI YAML can't be run locally, so a couple of assumptions to sanity-check:
- The pinned `contract-tests@contract-tests-v1.3.0` action supports `version: v3` / `branch: v3` (cpp uses the same action with v3).
- FDv1 and FDv2 share `testharness-suppressions.txt` (the v3 run passes with it; cpp keeps a separate `*-fdv2.txt` — we can split if preferred).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI and the contract-test adapter; production SDK behavior is exercised indirectly via harness mapping, with no auth or customer-facing API changes in this diff.
> 
> **Overview**
> Adds **FDv2 contract test coverage** in shared CI alongside the existing FDv1 run: the FDv1 step is labeled explicitly, then a second pass **restarts** the Flutter contract test service and invokes `contract-tests` with **`version`/`branch` v3** (same suppressions file).
> 
> The **Flutter contract test service** is extended for the v3 harness: it advertises **`fdv1-fallback`** (and related) capabilities, accepts a **`dataSystem`** block on client creation (OpenAPI + codegen), and **`_mapDataSystem`** translates harness shapes (connection mode overrides, initializers/synchronizers, **`fdv1Fallback`**) into **`LDConfig.dataSystem`** and initial connection mode. Smaller harness fixes include omitting null evaluation **`value`** keys, stricter context casts, and **`Timeout.none`** on the long-running test server.
> 
> **`pubspec.lock`** bumps pinned local SDK packages used by the contract app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db189612a9faae054be5e4567355dabdeb928ffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->