### PR TITLE
feat: Update launchdarkly_event_source_client to version 3.0.0

### DIFF
--- a/packages/common_client/pubspec.yaml
+++ b/packages/common_client/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   http: ^1.1.2
   launchdarkly_dart_common: 1.8.1
-  launchdarkly_event_source_client: 2.2.0
+  launchdarkly_event_source_client: 3.0.0
   crypto: ^3.0.3
   meta: ^1.12.0
   uuid: ">= 3.0.7 <5.0.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> A major-version bump on the SSE client affects flag streaming connectivity; compatibility depends on whether 3.0.0 breaks APIs still used elsewhere in this repo without local code updates in this PR.
> 
> **Overview**
> Bumps the pinned **`launchdarkly_event_source_client`** dependency in `packages/common_client` from **2.2.0** to **3.0.0**. There are no accompanying source or test changes in this PR—only the `pubspec.yaml` version line.
> 
> That library backs SSE streaming used by FDv1 (`streaming_data_source`) and FDv2 streaming paths (`streaming_base`, `entry_factories`), so consumers of `launchdarkly_common_client` will resolve the new major on the next dependency update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b862292c0c3d40abcd39f3347d92cc465874f6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->