### PR TITLE
chore: Automatically update FDv2 example app SDK dependency.

### DIFF
--- a/packages/flutter_client_sdk/example_fdv2/pubspec.yaml
+++ b/packages/flutter_client_sdk/example_fdv2/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # This defaults to a published package. Using `flutter pub get` will get the
   # package from pub.dev. If you run `melos bs` in the root of the repository,
   # then it will be linked to the local version instead.
-  launchdarkly_flutter_client_sdk: 4.19.0
+  launchdarkly_flutter_client_sdk: 4.19.0 # x-release-please-version
   cupertino_icons: ^1.0.6
 
 dev_dependencies:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,6 +20,10 @@
         {
           "type": "generic",
           "path": "example/pubspec.yaml"
+        },
+        {
+          "type": "generic",
+          "path": "example_fdv2/pubspec.yaml"
         }
       ]
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release automation and example app dependency pins only; no runtime SDK or production code changes.
> 
> **Overview**
> Aligns the **FDv2 manual test app** with the existing `example` app so **release-please** keeps its pinned `launchdarkly_flutter_client_sdk` version in sync on SDK releases.
> 
> Adds `example_fdv2/pubspec.yaml` to `release-please-config.json` under `packages/flutter_client_sdk` `extra-files`, and marks the dependency with `# x-release-please-version` (same pattern as `example/pubspec.yaml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cd8a2ce409c1f4cf53e9ef89b35edf835ea047d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->