### PR TITLE
fix: emit status event before closing controller on unrecoverable stream error

### DIFF
--- a/packages/common_client/lib/src/data_sources/streaming_data_source.dart
+++ b/packages/common_client/lib/src/data_sources/streaming_data_source.dart
@@ -207,9 +207,11 @@ final class StreamingDataSource implements DataSource {
         _permanentShutdown = true;
         _logger.error(
             'Encountered an unrecoverable error: "$err", Shutting down.');
-        stop();
+        // The event must be added before calling stop, because stop closes
+        // the controller and adding an event after that throws a StateError.
         _dataController.sink.add(StatusEvent(ErrorKind.unknown, null,
             'Encountered unrecoverable error streaming'));
+        stop();
       });
   }
 

--- a/packages/common_client/test/data_sources/streaming_data_source_test.dart
+++ b/packages/common_client/test/data_sources/streaming_data_source_test.dart
@@ -504,6 +504,28 @@ void main() {
     });
   });
 
+  group('stream error handling', () {
+    test(
+        'it emits a status event without throwing when the stream reports an '
+        'unrecoverable error', () async {
+      final controller = StreamController<Event>();
+      final (dataSource, _, statusManager) =
+          makeDataSourceForTest(controller.stream);
+
+      final statusChange = expectLater(
+          statusManager.changes,
+          emits(predicate<DataSourceStatus>((status) =>
+              status.lastError?.kind == ErrorKind.unknown &&
+              status.lastError?.message ==
+                  'Encountered unrecoverable error streaming')));
+
+      dataSource.start();
+      controller.sink.addError(Exception('Unable to make request'));
+
+      await statusChange;
+    });
+  });
+
   group('environment ID from the stream connection', () {
     test('it uses the environment ID response header', () async {
       final controller = StreamController<Event>();


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

None filed — happy to open one if you prefer tracking it that way.

**Describe the solution you've provided**

In `StreamingDataSource`, the SSE subscription's `onError` handler handles an unrecoverable error by calling `stop()` — which closes `_dataController` — and then adds a `StatusEvent` to that now-closed controller:

```dart
stop();                                        // closes _dataController
_dataController.sink.add(StatusEvent(...));    // throws StateError
```

This throws `Bad state: Cannot add event after closing`, which surfaces as an uncaught error in the host application (we see this in production via Crashlytics — 44 users / 65 events in the last week on our app alone, reported at `streaming_data_source.dart:203` on v1.9.0; the same code is present on `main`). It also means consumers never receive the final `StatusEvent`, since the controller is already closed when it's added.

The trigger in the field is an unrecoverable error from the event source client (e.g. `Unable to make request`), which we most often see when the app resumes from background and the connection can't be re-established.

This PR reorders the two statements so the `StatusEvent` is added before `stop()` closes the controller — matching the ordering `PollingDataSource` already uses (event added first, `stop()` after). A regression test is included; it fails against the previous ordering and passes with this change.

One thing I deliberately left unchanged for the maintainers to consider: this `StatusEvent` is emitted with `shutdown: false` even though the source is permanently shutting down (`_permanentShutdown = true`). Setting `shutdown: true` might be more accurate, but it changes downstream state handling, so I kept this fix minimal.

**Describe alternatives you've considered**

Guarding the add with `if (!_dataController.isClosed)` would prevent the crash but would still silently drop the final status event; reordering both fixes the crash and delivers the event.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small ordering fix in error shutdown with a targeted test; no auth or data-model changes.
> 
> **Overview**
> Fixes a production crash when the SSE stream hits an **unrecoverable** error (e.g. after resume from background): `onError` used to call `stop()` first, which closes `_dataController`, then add a `StatusEvent`—that second step threw **Bad state: Cannot add event after closing** and consumers never saw the final error status.
> 
> The handler now **emits the `StatusEvent` first**, then calls `stop()`, aligned with how `PollingDataSource` orders shutdown. A regression test asserts the status update is delivered without throwing when the mock stream reports an unrecoverable error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cec4b05ef411f1c605b4922e6104b54e456e136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


  BEGIN_COMMIT_OVERRIDE
  fix: emit status event before closing controller on unrecoverable stream error
  END_COMMIT_OVERRIDE