### PR TITLE
chore: allow release-please workflow to be run via workflow_dispatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch:` to `.github/workflows/release-please.yml` so the release-please workflow can be re-fired manually from the Actions UI without pushing a commit to `main`.

## Motivation

When a commit lands on `main` whose message release-please can't parse (e.g. run [29123151878](https://github.com/launchdarkly/flutter-client-sdk/actions/runs/29123151878/job/86462658991), where the squash-merge body of PR #324 tripped the conventional-commits parser), the workflow completes without opening a release PR. Recovering currently requires either editing the offending PR body (to add a `BEGIN_COMMIT_OVERRIDE` block) and then pushing another commit to `main` to retrigger, or landing a follow-up commit whose sole purpose is to fire the workflow. Adding `workflow_dispatch` lets us edit the PR body and click "Run workflow" from the Actions UI instead.

## Test plan

- [ ] After merge, the release-please workflow appears in the Actions UI with a "Run workflow" button on the `main` branch and re-runs cleanly on demand.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single trigger addition on an existing release automation workflow; no change to release-please steps, permissions, or publishing behavior.
> 
> **Overview**
> Adds **`workflow_dispatch`** to **`release-please.yml`**, so release-please can be started from the GitHub Actions UI in addition to pushes to **`main`**.
> 
> This supports recovery when a **`main`** push does not produce a release PR (for example, a squash-merge message that release-please cannot parse). After fixing the PR body or related metadata, you can re-run the workflow without pushing a no-op commit to **`main`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90555f69a12c032cd63ee49cfc3ff7fa8a61aaaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->