### PR TITLE
fix: add defensive cycle guard to prerequisite evaluation

### DIFF
--- a/apps/flutter_client_contract_test_service/bin/contract_test_service.dart
+++ b/apps/flutter_client_contract_test_service/bin/contract_test_service.dart
@@ -27,6 +27,7 @@ class TestApiImpl extends SdkTestApi {
     'anonymous-redaction',
     'client-per-context-summaries',
     'client-prereq-events',
+    'client-prereq-cycle-detection',
     'auto-env-attributes',
     'client-event-source-http-errors',
     'fdv1-fallback',

--- a/packages/common_client/lib/src/ld_common_client.dart
+++ b/packages/common_client/lib/src/ld_common_client.dart
@@ -772,15 +772,39 @@ final class LDCommonClient {
 
   LDEvaluationDetail<LDValue> _variationInternal(
       String flagKey, LDValue defaultValue,
-      {required bool isDetailed, LDValueType? type}) {
+      {required bool isDetailed, LDValueType? type, Set<String>? visited}) {
     final evalResult = _flagManager.get(flagKey);
 
     LDEvaluationDetail<LDValue> detail;
 
     if (evalResult != null && evalResult.flag != null) {
-      evalResult.flag?.prerequisites?.forEach((prereq) {
-        _variationInternal(prereq, LDValue.ofNull(), isDetailed: isDetailed);
-      });
+      final prerequisites = evalResult.flag!.prerequisites;
+      if (prerequisites != null && prerequisites.isNotEmpty) {
+        // Recurse on prerequisites to emulate prereq evaluations occurring with
+        // desirable side effects such as events for prereqs.
+        //
+        // `visited` tracks the chain of prerequisite dependencies from the
+        // top-level evaluation to (but not including) the current flag. It is
+        // allocated lazily: variation calls on prereq-less flags allocate no
+        // set. Once created it is shared for the rest of the walk via
+        // add-before-recurse / remove-after-recurse in a finally block.
+        final ancestors = visited ?? <String>{};
+        ancestors.add(flagKey);
+        try {
+          for (final prereq in prerequisites) {
+            if (ancestors.contains(prereq)) {
+              // Cyclic edge: skip descent, continue with remaining
+              // prerequisites at this level. The requested flag's value and
+              // reason are unaffected.
+              continue;
+            }
+            _variationInternal(prereq, LDValue.ofNull(),
+                isDetailed: isDetailed, visited: ancestors);
+          }
+        } finally {
+          ancestors.remove(flagKey);
+        }
+      }
 
       if (type == null || type == evalResult.flag!.detail.value.type) {
         detail = evalResult.flag!.detail;

--- a/packages/common_client/test/ld_dart_client_test.dart
+++ b/packages/common_client/test/ld_dart_client_test.dart
@@ -450,8 +450,7 @@ void main() {
       );
     });
 
-    test(
-        'emits the shared descendant once per path in a non-cyclic diamond',
+    test('emits the shared descendant once per path in a non-cyclic diamond',
         () async {
       // Diamond: A -> [B, C], B -> [D], C -> [D]. Not a cycle. Ancestor-set
       // (current-path) semantics let D be reached on each of the two independent

--- a/packages/common_client/test/ld_dart_client_test.dart
+++ b/packages/common_client/test/ld_dart_client_test.dart
@@ -393,5 +393,76 @@ void main() {
       expect(mockEventProcessor.evalEvents[0].flagKey, 'flagAB');
       expect(mockEventProcessor.evalEvents[1].flagKey, 'flagA');
     });
+
+    // Cycle-detection tests exercise the ancestor-set cycle guard added to
+    // _variationInternal. Each test constructs a cyclic prereq graph via the
+    // storage fixture, evaluates one flag on the cycle, and asserts (a) the
+    // requested flag returns its cached value unchanged and (b) the recorded
+    // evaluation events match exactly one entry per cycle-safe descent.
+    Future<void> runCycleCase(String storageJson, String evalKey,
+        List<String> expectedEventKeys) async {
+      final contextPersistenceKey =
+          sha256.convert(utf8.encode('bob')).toString();
+      mockPersistence.storage[sdkKeyPersistence] = {
+        contextPersistenceKey: storageJson,
+      };
+      await client.start();
+      final res = client.stringVariation(evalKey, 'default');
+      expect(res, 'cached');
+      expect(mockEventProcessor.evalEvents.map((e) => e.flagKey).toList(),
+          expectedEventKeys);
+    }
+
+    test('skips a self-loop prerequisite and returns the cached value',
+        () async {
+      // flagA's only prerequisite is itself; the cycle guard skips descent.
+      await runCycleCase(
+        '{"flagA":{"version":1,"value":"cached","variation":0,"reason":{"kind":"OFF"},"prerequisites":["flagA"]}}',
+        'flagA',
+        ['flagA'],
+      );
+    });
+
+    test('handles a two-cycle evaluating A', () async {
+      // A -> B -> [A skipped]. Events deepest-first: B (as prereq of A), then A.
+      await runCycleCase(
+        '{"flagA":{"version":1,"value":"cached","variation":0,"reason":{"kind":"OFF"},"prerequisites":["flagB"]},"flagB":{"version":1,"value":"cached","variation":0,"reason":{"kind":"OFF"},"prerequisites":["flagA"]}}',
+        'flagA',
+        ['flagB', 'flagA'],
+      );
+    });
+
+    test('handles a two-cycle evaluating B', () async {
+      // Symmetric: same graph, entry from B. Events: A (as prereq of B), then B.
+      await runCycleCase(
+        '{"flagA":{"version":1,"value":"cached","variation":0,"reason":{"kind":"OFF"},"prerequisites":["flagB"]},"flagB":{"version":1,"value":"cached","variation":0,"reason":{"kind":"OFF"},"prerequisites":["flagA"]}}',
+        'flagB',
+        ['flagA', 'flagB'],
+      );
+    });
+
+    test('handles a three-cycle', () async {
+      // A -> B -> C -> [A skipped]. Events emitted deepest-first: C, B, A.
+      await runCycleCase(
+        '{"flagA":{"version":1,"value":"cached","variation":0,"reason":{"kind":"OFF"},"prerequisites":["flagB"]},"flagB":{"version":1,"value":"cached","variation":0,"reason":{"kind":"OFF"},"prerequisites":["flagC"]},"flagC":{"version":1,"value":"cached","variation":0,"reason":{"kind":"OFF"},"prerequisites":["flagA"]}}',
+        'flagA',
+        ['flagC', 'flagB', 'flagA'],
+      );
+    });
+
+    test(
+        'emits the shared descendant once per path in a non-cyclic diamond',
+        () async {
+      // Diamond: A -> [B, C], B -> [D], C -> [D]. Not a cycle. Ancestor-set
+      // (current-path) semantics let D be reached on each of the two independent
+      // paths, so D emits twice. A naive "visited across the whole walk"
+      // implementation would drop the second event; this case guards against
+      // that regression.
+      await runCycleCase(
+        '{"flagA":{"version":1,"value":"cached","variation":0,"reason":{"kind":"OFF"},"prerequisites":["flagB","flagC"]},"flagB":{"version":1,"value":"cached","variation":0,"reason":{"kind":"OFF"},"prerequisites":["flagD"]},"flagC":{"version":1,"value":"cached","variation":0,"reason":{"kind":"OFF"},"prerequisites":["flagD"]},"flagD":{"version":1,"value":"cached","variation":0,"reason":{"kind":"OFF"}}}',
+        'flagA',
+        ['flagD', 'flagB', 'flagD', 'flagC', 'flagA'],
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

Adds defensive cycle detection to the recursive prerequisite walk in `LDCommonClient._variationInternal`, bringing the Flutter client SDK's behavior into line with the LaunchDarkly server SDK evaluators.

Tracker: [SDK-2705](https://launchdarkly.atlassian.net/browse/SDK-2705). Parent: [SDK-2695](https://launchdarkly.atlassian.net/browse/SDK-2695). Spec change: [sdk-specs#246](https://github.com/launchdarkly/sdk-specs/pull/246) (CSPE 1.2.5, 1.2.5.1, 1.2.5.2). Contract-test coverage: [sdk-test-harness#384](https://github.com/launchdarkly/sdk-test-harness/pull/384) (merged in v2.38.0). Companion PRs: [android-client-sdk#377](https://github.com/launchdarkly/android-client-sdk/pull/377), [ios-client-sdk#512](https://github.com/launchdarkly/ios-client-sdk/pull/512), [js-core#1816](https://github.com/launchdarkly/js-core/pull/1816).

## Background

The LaunchDarkly service validates prerequisite graphs on every mutation and rejects any change that would produce a cycle, so under normal operation the SDK does not see a cyclic prerequisite graph. Server-side SDK evaluators nonetheless carry defensive cycle detection for exceptional cases — for example, delivery of updates out of order or a persisted state loaded from disk that predates a subsequent correction. This PR extends the same defensive posture to the Flutter client SDK.

## The fix

`_variationInternal` now threads a lazily-allocated `Set<String>?` through the recursion carrying the flag keys on the current evaluation path. Before descending into a prerequisite, the walker checks whether that key is already on the path; if so, it skips that edge and continues with remaining prerequisites at the same level.

- **Lazy allocation**: variation calls on prereq-less flags (the common case) allocate zero collections. The `Set<String>` is created only when the walker descends into a prerequisite for the first time in a call, then reused for the rest of the walk.
- **Mutable `add` / `finally remove`**: no per-descent copy. `ancestors.add(flagKey)` before recursing, `ancestors.remove(flagKey)` in a `finally` — the invariant "the set contains exactly the current path" holds even under early exits.
- **Ancestor-set (current-path) semantics** — this is deliberate. A prerequisite reached via multiple non-cyclic paths (a diamond `A -> [B, C], B -> [D], C -> [D]`) is not a cycle; each path should emit its own prerequisite event. A global visited-set would silently drop the second event; the ancestor-set pattern correctly emits D twice. There is a unit test guarding this.

The optional named parameter `visited` is added last, so all existing callers (the seven typed and untyped `variation` / `variationDetail` entry points) work unchanged.

## Caller-visible behavior on a cycle

The requested flag returns its cached value and reason unchanged. A client-side prerequisite cycle is not surfaced as `MALFORMED_FLAG` and does not fall back to the caller-provided default value. This differs from server-side behavior — the client already holds an authoritative pre-evaluated result from the server; only the ancillary event walk is affected by the cycle.

## Files changed

- `packages/common_client/lib/src/ld_common_client.dart` — cycle guard in `_variationInternal`.
- `packages/common_client/test/ld_dart_client_test.dart` — 5 new tests under the existing `given mock flag data with prerequisites` group: self-loop, two-cycle (evaluating each end), three-cycle, and a non-cyclic diamond that asserts the shared descendant emits an event for each path (the ancestor-set regression fence).
- `apps/flutter_client_contract_test_service/bin/contract_test_service.dart` — declares `client-prereq-cycle-detection` so the matching contract tests in sdk-test-harness v2.38.0+ activate for this SDK.

## Verification

- **Unit tests**: `dart test test/ld_dart_client_test.dart` → 31 tests, 0 failures. The 5 new cycle-detection tests all pass.

## Changelog

> Updated prerequisite evaluation event emission to match server SDK behavior for cyclic prerequisite graphs.

[SDK-2705]: https://launchdarkly.atlassian.net/browse/SDK-2705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-2695]: https://launchdarkly.atlassian.net/browse/SDK-2695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes flag evaluation’s prerequisite recursion and analytics event ordering, but behavior is narrowly scoped to abnormal cyclic graphs and is covered by new unit and contract tests.
> 
> **Overview**
> Adds **defensive cycle detection** to the recursive prerequisite walk in `LDCommonClient._variationInternal`, matching server SDK behavior when a cyclic prereq graph appears (e.g. stale persisted state).
> 
> The walker threads a lazily allocated **ancestor set** (current path only): before recursing into a prerequisite it skips edges whose key is already on the path, then continues with other prerequisites. The evaluated flag still returns its **cached value and reason**; only the ancillary prereq event walk is affected. **Diamond graphs** still emit one prereq event per independent path (not treated as cycles).
> 
> Adds five unit tests (self-loop, 2- and 3-cycles, diamond regression) and advertises the **`client-prereq-cycle-detection`** contract-test capability on the Flutter contract test service.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ea0310d8f4ea3091eda97d0fb784f6fd2897d73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->