### PR TITLE
chore: record fdv2 support in sdk metadata

### DIFF
--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -17,6 +17,7 @@
         "bigSegments": { "introduced": "1.0" },
         "contexts": { "introduced": "2.0" },
         "experimentation": { "introduced": "1.0" },
+        "fdv2": { "introduced": "4.20" },
         "flagChanges": { "introduced": "1.0" },
         "hooks": { "introduced": "4.12" },
         "inlineContextCustomEvents": { "introduced": "4.11.1" },


### PR DESCRIPTION
## Summary

Records FDv2 support in `.sdk_metadata.json`, introduced in 4.20.

Updating here so it's reflected in sdk-meta.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`fdv2`** to the Flutter Client SDK feature list in **`.sdk_metadata.json`**, with **`introduced": "4.20"`**, so sdk-meta reflects FDv2 support that shipped in 4.20.
> 
> No runtime or SDK code changes—metadata only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b1923c9b7700448ff1b8b90ad5585ebf45f56f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->