### PR TITLE
fix: include flagVersion when serializing flag evaluations

### DIFF
--- a/packages/common/lib/src/serialization/ld_evaluation_result_serialization.dart
+++ b/packages/common/lib/src/serialization/ld_evaluation_result_serialization.dart
@@ -35,6 +35,9 @@ final class LDEvaluationResultSerialization {
     Map<String, dynamic> result = {};
 
     result['version'] = evaluationResult.version;
+    if (evaluationResult.flagVersion != null) {
+      result['flagVersion'] = evaluationResult.flagVersion;
+    }
     if (evaluationResult.trackEvents) {
       result['trackEvents'] = evaluationResult.trackEvents;
     }

--- a/packages/common/test/serialization/ld_evaluation_result_serialization_test.dart
+++ b/packages/common/test/serialization/ld_evaluation_result_serialization_test.dart
@@ -27,7 +27,11 @@ void main() {
       LDEvaluationResult(
           version: 5,
           detail: basicEvalReason,
-          debugEventsUntilDate: DateTime.now().millisecondsSinceEpoch)
+          debugEventsUntilDate: DateTime.now().millisecondsSinceEpoch),
+      // The store version and the flag version are independent: under FDv2
+      // the wire object carries only flagVersion and the version comes from
+      // the payload envelope. Both must survive a round trip.
+      LDEvaluationResult(version: 40, flagVersion: 12, detail: basicEvalReason)
     ]) {
       test('it can serialize/deserialize the evaluation detail: $result', () {
         var serialized =
@@ -37,5 +41,22 @@ void main() {
         expect(deserialized, result);
       });
     }
+  });
+
+  test('it serializes flagVersion when it is set', () {
+    final result = LDEvaluationResult(
+        version: 40, flagVersion: 12, detail: basicEvalReason);
+
+    final json = LDEvaluationResultSerialization.toJson(result);
+
+    expect(json['flagVersion'], 12);
+  });
+
+  test('it omits flagVersion when it is not set', () {
+    final result = LDEvaluationResult(version: 40, detail: basicEvalReason);
+
+    final json = LDEvaluationResultSerialization.toJson(result);
+
+    expect(json.containsKey('flagVersion'), isFalse);
   });
 }

--- a/packages/common/test/serialization/ld_evaluation_results_serialization_test.dart
+++ b/packages/common/test/serialization/ld_evaluation_results_serialization_test.dart
@@ -29,7 +29,9 @@ void main() {
       'withDate': LDEvaluationResult(
           version: 5,
           detail: basicEvalReason,
-          debugEventsUntilDate: DateTime.now().millisecondsSinceEpoch)
+          debugEventsUntilDate: DateTime.now().millisecondsSinceEpoch),
+      'withFlagVersion': LDEvaluationResult(
+          version: 40, flagVersion: 12, detail: basicEvalReason)
     };
 
     final serialized =
@@ -37,6 +39,6 @@ void main() {
     final deserialized =
         LDEvaluationResultsSerialization.fromJson(jsonDecode(serialized));
 
-    deserialized.equals(results);
+    expect(deserialized.equals(results), isTrue);
   });
 }

--- a/packages/common_client/test/flag_persistence_test.dart
+++ b/packages/common_client/test/flag_persistence_test.dart
@@ -223,6 +223,53 @@ void main() {
       expect(flagStore.getAll().equals(basicData), true);
     });
 
+    test('it round trips flagVersion through the cache', () async {
+      // Under FDv2 the store version comes from the payload envelope while
+      // flagVersion is the flag's own version, so the two differ. If
+      // flagVersion is lost here, evaluation events restored from the cache
+      // report the envelope version instead of the flag version.
+      final flagData = {
+        'flagA': ItemDescriptor(
+            version: 40,
+            flag: LDEvaluationResult(
+                version: 40,
+                flagVersion: 12,
+                detail: LDEvaluationDetail(
+                    LDValue.ofString('test'), 0, LDEvaluationReason.off())))
+      };
+
+      final flagStore = FlagStore();
+      final mockPersistence = MockPersistence();
+      final flagPersistence = FlagPersistence(
+          persistence: mockPersistence,
+          updater: FlagUpdater(flagStore: flagStore, logger: logger),
+          store: flagStore,
+          sdkKey: sdkKey,
+          maxCachedContexts: 5,
+          logger: logger,
+          stamper: () => DateTime.fromMillisecondsSinceEpoch(0));
+
+      final context = LDContextBuilder().kind('user', 'user-key').build();
+
+      await flagPersistence.init(context, flagData);
+
+      final contextPersistenceKey =
+          sha256.convert(utf8.encode(context.canonicalKey)).toString();
+
+      expect(
+          mockPersistence.storage[sdkKeyPersistence]![contextPersistenceKey],
+          '{"flagA":{'
+          '"version":40,'
+          '"flagVersion":12,'
+          '"value":"test",'
+          '"variation":0,'
+          '"reason":{"kind":"OFF"}'
+          '}}');
+
+      final cached = await flagPersistence.readCached(context);
+      expect(cached!.flags['flagA']!.flagVersion, 12);
+    });
+
     test('it updates cache on upsert', () async {
       final flagStore = FlagStore();
       final mockPersistence = MockPersistence();


### PR DESCRIPTION
## Problem

`LDEvaluationResultSerialization.fromJson` reads `flagVersion`, but `toJson` never wrote it. That serializer's only production caller is `FlagPersistence._storeCache`, so the local flag cache was written without `flagVersion`.

On the next app start, flags restored from the cache (`readCached` / `loadCached` — used by both the FDv1 identify path and the FDv2 cache initializer) had `flagVersion == null`. `LDCommonClient` builds evaluation events with `flagVersion ?? version`, so both `feature`/`debug` events and summary counters reported the store version until fresh data arrived from the data source.

This is most pronounced under FDv2: the wire object carries only `flagVersion`, and `flag_eval_mapper` synthesizes `version` from the payload envelope. So cached FDv2 flags produced events carrying a payload sequence number that never corresponded to a real flag version. Under FDv1 both fields are on the wire and genuinely differ, so it was wrong there too, just less arbitrary.

`flagVersion` was the only field in the model that `fromJson` read and `toJson` did not write.

## Fix

Write `flagVersion` in `toJson` when it is set. Conditional, to match the surrounding style and keep the key absent rather than `null` when unset — which is what `fromJson` already tolerates, so old caches keep deserializing exactly as before.

## Testing

- New round-trip case plus two explicit assertions in `ld_evaluation_result_serialization_test.dart`, and a `withFlagVersion` entry in the map-level test. All fail without the fix (verified by stashing only the source change) and pass with it.
- New `it round trips flagVersion through the cache` in `flag_persistence_test.dart` covers where the bug actually bites: store → persist → `readCached`. Also fails without the fix.
- The map-level round-trip test's assertion result was previously discarded (`deserialized.equals(results);` with no `expect`), so it could never fail. Given a real `expect` here, since that is why this gap went unnoticed.
- Full `common` and `common_client` suites pass; `dart analyze` clean on both; formatter reports no changes.
- Contract tests run locally against both harnesses:
  - FDv1 (harness v2.41.0): all tests passed — 865 total, 20 skipped, 845 ran.
  - FDv2 (harness v3.2.0-alpha.9): all tests passed — 824 total, 21 skipped, 803 ran.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes a one-way serialization gap: **`LDEvaluationResultSerialization.toJson`** now writes **`flagVersion`** when it is set (and leaves the key out when unset), matching **`fromJson`** and the other optional fields.
> 
> That matters because flag persistence serializes evaluations through this path; without **`flagVersion`** on disk, flags restored from the local cache had **`flagVersion == null`**, so evaluation events used **`version`** instead—especially wrong under FDv2 where store **`version`** and flag **`flagVersion`** differ.
> 
> Tests add round-trip coverage for **`flagVersion`**, assert omit-when-unset behavior, fix a map-level test that never **`expect`**’d equality, and add a **`FlagPersistence`** test that **`flagVersion`** survives store → cache → **`readCached`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 901aa4205c6e34007759fa33a398413ea3b3f2e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->