### PR TITLE
fix: Update launchdarkly_dart_common to version 1.8.2

### DIFF
--- a/packages/common_client/pubspec.yaml
+++ b/packages/common_client/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   http: ^1.1.2
-  launchdarkly_dart_common: 1.8.1
+  launchdarkly_dart_common: 1.8.2
   launchdarkly_event_source_client: 3.0.0
   crypto: ^3.0.3
   meta: ^1.12.0


### PR DESCRIPTION
Propagates the `flagVersion` serialization fix (#335, released as `launchdarkly_dart_common` 1.8.2 in #337) down to `launchdarkly_common_client`.

`common_client` pins `launchdarkly_dart_common` exactly, so the fix does not reach it without this edit. Without this bump, the pending `common_client` 1.14.3 release (#336) would ship a changelog crediting the fix while still resolving 1.8.1, which does not contain it — the fix lives entirely in `packages/common`.

Landing this before #336 merges folds the commit into that release, so 1.14.3 genuinely carries the fix.

Next hop after this: bump `launchdarkly_common_client` in `packages/flutter_client_sdk/pubspec.yaml` to 1.14.3, which produces the Flutter SDK release users actually consume.

Same shape as the prior propagation commits: 0e5301d (`fix: Update launchdarkly_dart_common to version 1.8.1`, #277) and 48f6790 (`fix: Update launchdarkly_common_client to version 1.14.2`, #331).

Note: CI resolves `common` through the melos path override (`melos bs`), so it passes independently of pub.dev. The `common_client` *publish* does require 1.8.2 to be live on pub.dev, so #336 should merge only after the 1.8.2 publish run completes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Bumps the pinned **`launchdarkly_dart_common`** dependency in **`launchdarkly_common_client`** from **1.8.1** to **1.8.2**, so the client package actually picks up the **`flagVersion`** serialization fix shipped in common.
> 
> Because **`common_client`** uses an exact version pin, the fix does not flow through until this change; it aligns the dependency with the upcoming **1.14.3** release so published artifacts match the credited bug fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bc696990be39eec5dfd868cfa43ec8469ab0702. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->