### PR TITLE
fix: Update launchdarkly_common_client to version 1.14.3

### DIFF
--- a/packages/flutter_client_sdk/pubspec.yaml
+++ b/packages/flutter_client_sdk/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   package_info_plus: ">=4.2.0 <11.0.0"
   device_info_plus: ">=9.1.1 <14.0.0"
-  launchdarkly_common_client: 1.14.2
+  launchdarkly_common_client: 1.14.3
   shared_preferences: ^2.2.2
   connectivity_plus: ">=5.0.2 <8.0.0"
   web: ^1.1.1


### PR DESCRIPTION
Final hop propagating the `flagVersion` serialization fix (#335) out to the published Flutter SDK.

`flutter_client_sdk` pins `launchdarkly_common_client` exactly, so the fix does not reach SDK users without this edit. This is the only place in the repo pinning `common_client`.

Chain so far:

| Package | Version | Status |
| --- | --- | --- |
| `launchdarkly_dart_common` | 1.8.2 | published — contains the fix (#335, #337) |
| `launchdarkly_common_client` | 1.14.3 | published — pins common 1.8.2 (#338, #336) |
| `launchdarkly_flutter_client_sdk` | 4.20.3 | this PR triggers the release |

1.14.3 is already live on pub.dev, so there is no publish-ordering constraint: this can merge as soon as CI is green, and the resulting 4.20.3 release PR after it.

Same shape as the prior propagation commits: 48f6790 (`fix: Update launchdarkly_common_client to version 1.14.2`, #331) and 0e5301d (`fix: Update launchdarkly_dart_common to version 1.8.1`, #277).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Bumps the **exact** `launchdarkly_common_client` pin in `flutter_client_sdk` from **1.14.2** to **1.14.3** so published Flutter SDK users pick up the upstream fix for **`flagVersion` in flag evaluation serialization** (via `launchdarkly_dart_common` 1.8.2).
> 
> No Dart/Flutter source changes—only `pubspec.yaml`. This is the last hop in the version propagation chain before a **4.20.3** Flutter SDK release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ff98a9eb499659a200750c521188f58400dfae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

BEGIN_COMMIT_OVERRIDE
fix: Update launchdarkly_common_client to version 1.14.3
fix: Includes fix for flagVersion tracking in events
END_COMMIT_OVERRIDE
