### PR TITLE
chore: Add a melos script for the FDv2 contract tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ To run the unit tests for the SDK, run `melos run test` in the SDK repo. These t
 
 To run the SSE contract tests, run `melos run sse-contract-tests` in the SDK repo.
 
-To run the client-side contract tests, run `melos run client-contract-tests` in the SDK repo.
+To run the client-side contract tests, run `melos run client-contract-tests` (FDv1, sdk-test-harness v2) and `melos run client-contract-tests-fdv2` (FDv2, sdk-test-harness v3) in the SDK repo. CI runs both.
 
 ### Code Coverage
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -43,7 +43,15 @@ scripts:
       curl -s https://raw.githubusercontent.com/launchdarkly/sse-contract-tests/v2.0.0/downloader/run.sh | VERSION=v2 PARAMS="-url http://localhost:8080 -debug -stop-service-at-end" sh
 
   client-contract-tests:
+    description: Runs the FDv1 client-side contract tests (sdk-test-harness v2).
     run: >
       cd apps/flutter_client_contract_test_service &&
       flutter test bin/contract_test_service.dart &
       cd apps/flutter_client_contract_test_service && curl -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/main/downloader/run.sh | VERSION=v2 PARAMS="-url http://localhost:8080 -debug -status-timeout 100 -stop-service-at-end -skip-from testharness-suppressions.txt" sh
+
+  client-contract-tests-fdv2:
+    description: Runs the FDv2 client-side contract tests (sdk-test-harness v3), as CI does.
+    run: >
+      cd apps/flutter_client_contract_test_service &&
+      flutter test bin/contract_test_service.dart &
+      cd apps/flutter_client_contract_test_service && curl -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/v3/downloader/run.sh | VERSION=v3 PARAMS="-url http://localhost:8080 -debug -status-timeout 100 -stop-service-at-end -skip-from testharness-suppressions.txt" sh


### PR DESCRIPTION
## Summary

CI runs the client-side contract tests twice: the FDv1 suite with sdk-test-harness v2 and the FDv2 suite with sdk-test-harness v3 (the "Contract Tests (FDv2)" step in the shared CI action). Locally, `melos run client-contract-tests` only covered the v2 run, so the FDv2 suite had no one-command local equivalent.

- Adds `melos run client-contract-tests-fdv2`, which starts the contract test service and runs the v3 harness with the same parameters and suppressions file as CI.
- Gives both contract-test scripts a description and points CONTRIBUTING.md at both.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`melos run client-contract-tests-fdv2`** so developers can run the FDv2 client-side contract suite locally with **sdk-test-harness v3**, matching the CI “Contract Tests (FDv2)” step. The existing **`client-contract-tests`** script is unchanged in behavior but now has a description labeling it as FDv1 / harness v2.
> 
> **CONTRIBUTING.md** is updated to document both commands and note that CI runs both suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d360030fee55f86949f308e028a9b84859d2d68a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->